### PR TITLE
Add anti-cheat humanization layer

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -17,6 +17,7 @@
 
 package baritone.api;
 
+import baritone.api.behavior.IHumanizationBehavior;
 import baritone.api.behavior.ILookBehavior;
 import baritone.api.behavior.IPathingBehavior;
 import baritone.api.cache.IWorldProvider;
@@ -45,6 +46,12 @@ public interface IBaritone {
      * @see ILookBehavior
      */
     ILookBehavior getLookBehavior();
+
+    /**
+     * @return The {@link IHumanizationBehavior} instance
+     * @see IHumanizationBehavior
+     */
+    IHumanizationBehavior getHumanizationBehavior();
 
     /**
      * @return The {@link IFollowProcess} instance

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -797,6 +797,28 @@ public final class Settings {
     public final Setting<Boolean> antiCheatCompatibility = new Setting<>(true);
 
     /**
+     * Applies a subtle "humanization" layer while {@link #antiCheatCompatibility} is enabled. The layer introduces
+     * small rotational drift and movement variations so that Baritone's control inputs look closer to real player
+     * behaviour for modern anti-cheat checks.
+     */
+    public final Setting<Boolean> antiCheatHumanization = new Setting<>(true);
+
+    /**
+     * The maximum angle (in degrees) that the humanization layer may drift rotations away from the exact target.
+     */
+    public final Setting<Float> antiCheatHumanizationAngle = new Setting<>(0.45f);
+
+    /**
+     * The maximum offset applied to the player's strafe/forward impulses while the humanization layer is active.
+     */
+    public final Setting<Float> antiCheatHumanizationMovement = new Setting<>(0.12f);
+
+    /**
+     * Average amount of ticks between humanization adjustments. Larger values slow down how often new offsets are picked.
+     */
+    public final Setting<Integer> antiCheatHumanizationInterval = new Setting<>(6);
+
+    /**
      * Exclusively use cached chunks for pathing
      * <p>
      * Never turn this on

--- a/src/api/java/baritone/api/behavior/IHumanizationBehavior.java
+++ b/src/api/java/baritone/api/behavior/IHumanizationBehavior.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.behavior;
+
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
+
+/**
+ * Provides access to the adaptive humanization layer. Implementations are responsible for
+ * recording player telemetry and producing snapshots of the accumulated profile so that other
+ * systems can synthesize "human-like" behavior.
+ */
+public interface IHumanizationBehavior extends IBehavior {
+
+    /**
+     * Starts recording the player's inputs and interactions. Recording sessions accumulate and are
+     * persisted across launches until {@link #resetProfile()} is invoked.
+     */
+    void startRecording();
+
+    /**
+     * Stops recording the player's inputs. Any captured samples are flushed to disk.
+     */
+    void stopRecording();
+
+    /**
+     * Clears all recorded samples and stored state.
+     */
+    void resetProfile();
+
+    /**
+     * @return whether a recording session is currently active.
+     */
+    boolean isRecording();
+
+    /**
+     * Returns an immutable snapshot of the accumulated humanization profile.
+     *
+     * @return the current snapshot.
+     */
+    HumanizationProfileSnapshot snapshot();
+}

--- a/src/api/java/baritone/api/behavior/humanization/HumanizationProfileSnapshot.java
+++ b/src/api/java/baritone/api/behavior/humanization/HumanizationProfileSnapshot.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.behavior.humanization;
+
+/**
+ * Immutable summary of the recorded humanization statistics.
+ */
+public final class HumanizationProfileSnapshot {
+
+    public static final HumanizationProfileSnapshot EMPTY = new HumanizationProfileSnapshot(
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            RunningStat.EMPTY,
+            0L
+    );
+
+    private final RunningStat movementMagnitude;
+    private final RunningStat strafeDelta;
+    private final RunningStat forwardDelta;
+    private final RunningStat yawDelta;
+    private final RunningStat pitchDelta;
+    private final RunningStat sprintReactionTicks;
+    private final RunningStat jumpReactionTicks;
+    private final RunningStat blockBreakDowntime;
+    private final RunningStat blockBreakDuration;
+    private final RunningStat blockPlaceInterval;
+    private final long recordedTicks;
+
+    public HumanizationProfileSnapshot(
+            RunningStat movementMagnitude,
+            RunningStat strafeDelta,
+            RunningStat forwardDelta,
+            RunningStat yawDelta,
+            RunningStat pitchDelta,
+            RunningStat sprintReactionTicks,
+            RunningStat jumpReactionTicks,
+            RunningStat blockBreakDowntime,
+            RunningStat blockBreakDuration,
+            RunningStat blockPlaceInterval,
+            long recordedTicks
+    ) {
+        this.movementMagnitude = movementMagnitude;
+        this.strafeDelta = strafeDelta;
+        this.forwardDelta = forwardDelta;
+        this.yawDelta = yawDelta;
+        this.pitchDelta = pitchDelta;
+        this.sprintReactionTicks = sprintReactionTicks;
+        this.jumpReactionTicks = jumpReactionTicks;
+        this.blockBreakDowntime = blockBreakDowntime;
+        this.blockBreakDuration = blockBreakDuration;
+        this.blockPlaceInterval = blockPlaceInterval;
+        this.recordedTicks = recordedTicks;
+    }
+
+    public RunningStat getMovementMagnitude() {
+        return this.movementMagnitude;
+    }
+
+    public RunningStat getStrafeDelta() {
+        return this.strafeDelta;
+    }
+
+    public RunningStat getForwardDelta() {
+        return this.forwardDelta;
+    }
+
+    public RunningStat getYawDelta() {
+        return this.yawDelta;
+    }
+
+    public RunningStat getPitchDelta() {
+        return this.pitchDelta;
+    }
+
+    public RunningStat getSprintReactionTicks() {
+        return this.sprintReactionTicks;
+    }
+
+    public RunningStat getJumpReactionTicks() {
+        return this.jumpReactionTicks;
+    }
+
+    public RunningStat getBlockBreakDowntime() {
+        return this.blockBreakDowntime;
+    }
+
+    public RunningStat getBlockBreakDuration() {
+        return this.blockBreakDuration;
+    }
+
+    public RunningStat getBlockPlaceInterval() {
+        return this.blockPlaceInterval;
+    }
+
+    public long getRecordedTicks() {
+        return this.recordedTicks;
+    }
+
+    public boolean hasMovementSamples() {
+        return this.movementMagnitude.hasSamples() || this.strafeDelta.hasSamples() || this.forwardDelta.hasSamples();
+    }
+
+    public boolean hasRotationSamples() {
+        return this.yawDelta.hasSamples() || this.pitchDelta.hasSamples();
+    }
+
+    public boolean hasSprintSamples() {
+        return this.sprintReactionTicks.hasSamples();
+    }
+
+    public boolean hasJumpSamples() {
+        return this.jumpReactionTicks.hasSamples();
+    }
+
+    public boolean hasBlockBreakSamples() {
+        return this.blockBreakDuration.hasSamples();
+    }
+
+    public boolean hasBlockPlaceSamples() {
+        return this.blockPlaceInterval.hasSamples();
+    }
+
+    /**
+     * Immutable summary of a running statistic.
+     */
+    public static final class RunningStat {
+
+        private static final RunningStat EMPTY = new RunningStat(0L, 0.0, 0.0, Double.NaN, Double.NaN);
+
+        private final long samples;
+        private final double mean;
+        private final double stdDev;
+        private final double min;
+        private final double max;
+
+        public RunningStat(long samples, double mean, double stdDev, double min, double max) {
+            this.samples = samples;
+            this.mean = mean;
+            this.stdDev = stdDev;
+            this.min = min;
+            this.max = max;
+        }
+
+        public long getCount() {
+            return this.samples;
+        }
+
+        public double getMean() {
+            return this.mean;
+        }
+
+        public double getStdDev() {
+            return this.stdDev;
+        }
+
+        public double getMin() {
+            return this.min;
+        }
+
+        public double getMax() {
+            return this.max;
+        }
+
+        public boolean hasSamples() {
+            return this.samples > 0L;
+        }
+    }
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -68,6 +68,7 @@ public class Baritone implements IBaritone {
 
     private final PathingBehavior pathingBehavior;
     private final LookBehavior lookBehavior;
+    private final HumanizationBehavior humanizationBehavior;
     private final InventoryBehavior inventoryBehavior;
     private final InputOverrideHandler inputOverrideHandler;
 
@@ -109,6 +110,7 @@ public class Baritone implements IBaritone {
             this.pathingBehavior      = this.registerBehavior(PathingBehavior::new);
             this.inventoryBehavior    = this.registerBehavior(InventoryBehavior::new);
             this.inputOverrideHandler = this.registerBehavior(InputOverrideHandler::new);
+            this.humanizationBehavior = this.registerBehavior(HumanizationBehavior::new);
             this.registerBehavior(WaypointBehavior::new);
         }
 
@@ -184,6 +186,11 @@ public class Baritone implements IBaritone {
 
     public InventoryBehavior getInventoryBehavior() {
         return this.inventoryBehavior;
+    }
+
+    @Override
+    public HumanizationBehavior getHumanizationBehavior() {
+        return this.humanizationBehavior;
     }
 
     @Override

--- a/src/main/java/baritone/behavior/HumanizationBehavior.java
+++ b/src/main/java/baritone/behavior/HumanizationBehavior.java
@@ -1,0 +1,299 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior;
+
+import baritone.Baritone;
+import baritone.api.behavior.IHumanizationBehavior;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
+import baritone.api.event.events.BlockChangeEvent;
+import baritone.api.event.events.BlockInteractEvent;
+import baritone.api.event.events.TickEvent;
+import baritone.api.event.events.WorldEvent;
+import baritone.api.event.events.type.EventState;
+import baritone.api.utils.Pair;
+import baritone.humanization.HumanizationProfile;
+import baritone.utils.PlayerMovementInput;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Records player telemetry and exposes adaptive humanization statistics.
+ */
+public final class HumanizationBehavior extends Behavior implements IHumanizationBehavior {
+
+    private static final int AUTOSAVE_INTERVAL_TICKS = 200;
+
+    private final Gson gson;
+    private final Path profileFile;
+    private final HumanizationProfile profile;
+
+    private HumanizationProfileSnapshot cachedSnapshot;
+    private boolean recording;
+    private boolean seededMovement;
+    private long tickCounter;
+    private long lastBlockBreakCompletionTick = -1L;
+    private long lastBlockPlaceTick = -1L;
+    private long lastSprintToggleTick = -1L;
+    private float lastStrafe;
+    private float lastForward;
+    private float lastYaw;
+    private float lastPitch;
+    private boolean lastSprinting;
+    private boolean dirty;
+    private int autosaveCountdown = AUTOSAVE_INTERVAL_TICKS;
+    private final Map<BlockPos, Long> activeBreakStarts = new HashMap<>();
+
+    public HumanizationBehavior(Baritone baritone) {
+        super(baritone);
+        this.gson = new GsonBuilder().setPrettyPrinting().create();
+        this.profileFile = baritone.getDirectory().resolve("humanization_profile.json");
+        this.profile = this.loadProfile();
+        this.cachedSnapshot = this.profile.snapshot();
+    }
+
+    @Override
+    public synchronized void startRecording() {
+        if (this.recording) {
+            return;
+        }
+        this.recording = true;
+        this.seededMovement = false;
+        this.tickCounter = 0L;
+        this.lastBlockBreakCompletionTick = -1L;
+        this.lastBlockPlaceTick = -1L;
+        this.lastSprintToggleTick = -1L;
+        this.activeBreakStarts.clear();
+        this.autosaveCountdown = AUTOSAVE_INTERVAL_TICKS;
+        this.seedFromPlayer();
+    }
+
+    @Override
+    public synchronized void stopRecording() {
+        if (!this.recording) {
+            return;
+        }
+        this.recording = false;
+        this.seededMovement = false;
+        this.activeBreakStarts.clear();
+        this.saveProfile();
+    }
+
+    @Override
+    public synchronized void resetProfile() {
+        this.profile.clear();
+        this.cachedSnapshot = HumanizationProfileSnapshot.EMPTY;
+        this.dirty = true;
+        this.saveProfile();
+    }
+
+    @Override
+    public synchronized boolean isRecording() {
+        return this.recording;
+    }
+
+    @Override
+    public synchronized HumanizationProfileSnapshot snapshot() {
+        if (this.cachedSnapshot == null) {
+            this.cachedSnapshot = this.profile.snapshot();
+        }
+        return this.cachedSnapshot;
+    }
+
+    @Override
+    public synchronized void onTick(TickEvent event) {
+        if (!this.recording || event.getType() != TickEvent.Type.IN) {
+            return;
+        }
+
+        final LocalPlayer player = this.ctx.player();
+        if (player == null) {
+            this.seededMovement = false;
+            return;
+        }
+
+        this.tickCounter++;
+
+        if (player.input instanceof PlayerMovementInput) {
+            this.seededMovement = false;
+            return;
+        }
+
+        this.profile.incrementRecordedTicks();
+
+        if (!this.seededMovement) {
+            this.seedFromPlayer();
+            return;
+        }
+
+        final float currentStrafe = player.xxa;
+        final float currentForward = player.zza;
+        this.profile.addMovementSample(Math.abs(currentStrafe - this.lastStrafe), Math.abs(currentForward - this.lastForward));
+        this.lastStrafe = currentStrafe;
+        this.lastForward = currentForward;
+
+        final float yaw = player.getYRot();
+        final float pitch = player.getXRot();
+        final float yawDelta = Mth.wrapDegrees(yaw - this.lastYaw);
+        final float pitchDelta = pitch - this.lastPitch;
+        this.profile.addRotationSample(Math.abs(yawDelta), Math.abs(pitchDelta));
+        this.lastYaw = yaw;
+        this.lastPitch = pitch;
+        this.markDirty();
+
+        final boolean sprinting = player.isSprinting();
+        if (sprinting != this.lastSprinting) {
+            if (this.lastSprintToggleTick >= 0L) {
+                this.profile.addSprintReaction((int) Math.min(Integer.MAX_VALUE, this.tickCounter - this.lastSprintToggleTick));
+                this.markDirty();
+            }
+            this.lastSprintToggleTick = this.tickCounter;
+            this.lastSprinting = sprinting;
+        }
+
+        if (this.dirty && --this.autosaveCountdown <= 0) {
+            this.saveProfile();
+            this.autosaveCountdown = AUTOSAVE_INTERVAL_TICKS;
+        }
+    }
+
+    @Override
+    public synchronized void onBlockInteract(BlockInteractEvent event) {
+        if (!this.recording || !this.isPlayerActivelyControlling()) {
+            return;
+        }
+
+        switch (event.getType()) {
+            case START_BREAK -> {
+                long now = this.tickCounter;
+                this.activeBreakStarts.put(event.getPos(), now);
+                if (this.lastBlockBreakCompletionTick >= 0L) {
+                    long downtime = Math.max(0L, now - this.lastBlockBreakCompletionTick);
+                    this.profile.addBlockBreakDowntime(downtime);
+                    this.markDirty();
+                }
+            }
+            case USE -> {
+                long now = this.tickCounter;
+                if (this.lastBlockPlaceTick >= 0L) {
+                    this.profile.addBlockPlaceInterval(Math.max(0L, now - this.lastBlockPlaceTick));
+                    this.markDirty();
+                }
+                this.lastBlockPlaceTick = now;
+            }
+        }
+    }
+
+    @Override
+    public synchronized void onBlockChange(BlockChangeEvent event) {
+        if (!this.recording || this.activeBreakStarts.isEmpty() || !this.isPlayerActivelyControlling()) {
+            return;
+        }
+
+        final long now = this.tickCounter;
+        for (Pair<BlockPos, BlockState> change : event.getBlocks()) {
+            final Long startTick = this.activeBreakStarts.get(change.first());
+            if (startTick != null && change.second().isAir()) {
+                this.activeBreakStarts.remove(change.first());
+                this.profile.addBlockBreakDuration(Math.max(0L, now - startTick));
+                this.lastBlockBreakCompletionTick = now;
+                this.markDirty();
+            }
+        }
+    }
+
+    @Override
+    public synchronized void onWorldEvent(WorldEvent event) {
+        if (event.getState() == EventState.POST) {
+            this.activeBreakStarts.clear();
+            this.lastBlockBreakCompletionTick = -1L;
+            this.lastBlockPlaceTick = -1L;
+            this.seededMovement = false;
+            this.saveProfile();
+        }
+    }
+
+    private void seedFromPlayer() {
+        final LocalPlayer player = this.ctx.player();
+        if (player == null || player.input instanceof PlayerMovementInput) {
+            this.seededMovement = false;
+            return;
+        }
+        this.lastStrafe = player.xxa;
+        this.lastForward = player.zza;
+        this.lastYaw = player.getYRot();
+        this.lastPitch = player.getXRot();
+        this.lastSprinting = player.isSprinting();
+        this.lastSprintToggleTick = -1L;
+        this.seededMovement = true;
+    }
+
+    private boolean isPlayerActivelyControlling() {
+        final LocalPlayer player = this.ctx.player();
+        return this.recording && player != null && !(player.input instanceof PlayerMovementInput);
+    }
+
+    private void markDirty() {
+        this.cachedSnapshot = null;
+        this.dirty = true;
+    }
+
+    private HumanizationProfile loadProfile() {
+        if (Files.exists(this.profileFile)) {
+            try (Reader reader = Files.newBufferedReader(this.profileFile, StandardCharsets.UTF_8)) {
+                HumanizationProfile loaded = this.gson.fromJson(reader, HumanizationProfile.class);
+                if (loaded != null) {
+                    return loaded;
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+        return new HumanizationProfile();
+    }
+
+    private void saveProfile() {
+        if (!this.dirty) {
+            return;
+        }
+        try {
+            Files.createDirectories(this.profileFile.getParent());
+            try (Writer writer = Files.newBufferedWriter(this.profileFile, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                this.gson.toJson(this.profile, writer);
+            }
+            this.cachedSnapshot = this.profile.snapshot();
+            this.dirty = false;
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -194,6 +194,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
         private final ForkableRandom rand;
         private double randomYawOffset;
         private double randomPitchOffset;
+        private float humanYawOffset;
+        private float humanPitchOffset;
+        private float targetHumanYawOffset;
+        private float targetHumanPitchOffset;
+        private int humanizationTicksRemaining;
 
         public AbstractAimProcessor(IPlayerContext ctx) {
             this.ctx = ctx;
@@ -205,6 +210,11 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             this.rand = source.rand.fork();
             this.randomYawOffset = source.randomYawOffset;
             this.randomPitchOffset = source.randomPitchOffset;
+            this.humanYawOffset = source.humanYawOffset;
+            this.humanPitchOffset = source.humanPitchOffset;
+            this.targetHumanYawOffset = source.targetHumanYawOffset;
+            this.targetHumanPitchOffset = source.targetHumanPitchOffset;
+            this.humanizationTicksRemaining = source.humanizationTicksRemaining;
         }
 
         @Override
@@ -223,6 +233,9 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             desiredYaw += this.randomYawOffset;
             desiredPitch += this.randomPitchOffset;
 
+            desiredYaw += this.humanYawOffset;
+            desiredPitch += this.humanPitchOffset;
+
             return new Rotation(
                     this.calculateMouseMove(prev.getYaw(), desiredYaw),
                     this.calculateMouseMove(prev.getPitch(), desiredPitch)
@@ -231,16 +244,19 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
 
         @Override
         public final void tick() {
+            final Settings settings = Baritone.settings();
             // randomLooking
-            this.randomYawOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
-            this.randomPitchOffset = (this.rand.nextDouble() - 0.5) * Baritone.settings().randomLooking.value;
+            this.randomYawOffset = (this.rand.nextDouble() - 0.5) * settings.randomLooking.value;
+            this.randomPitchOffset = (this.rand.nextDouble() - 0.5) * settings.randomLooking.value;
 
             // randomLooking113
             double random = this.rand.nextDouble() - 0.5;
             if (Math.abs(random) < 0.1) {
                 random *= 4;
             }
-            this.randomYawOffset += random * Baritone.settings().randomLooking113.value;
+            this.randomYawOffset += random * settings.randomLooking113.value;
+
+            this.updateHumanizedRotations(settings);
         }
 
         @Override
@@ -295,6 +311,40 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             return current + mouseToAngle(deltaPx);
         }
 
+        private void updateHumanizedRotations(Settings settings) {
+            if (!settings.antiCheatCompatibility.value || !settings.antiCheatHumanization.value) {
+                resetHumanizedRotations();
+                return;
+            }
+
+            if (this.humanizationTicksRemaining-- <= 0) {
+                final float maxAngle = Math.max(0.0f, settings.antiCheatHumanizationAngle.value);
+                this.targetHumanYawOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * maxAngle);
+                this.targetHumanPitchOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * maxAngle * 0.7f);
+
+                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
+                final int variance = Math.max(1, baseInterval);
+                this.humanizationTicksRemaining = baseInterval / 2 + boundedRandom(variance);
+            }
+
+            this.humanYawOffset += (this.targetHumanYawOffset - this.humanYawOffset) * 0.35f;
+            this.humanPitchOffset += (this.targetHumanPitchOffset - this.humanPitchOffset) * 0.35f;
+        }
+
+        private void resetHumanizedRotations() {
+            this.targetHumanYawOffset = 0.0f;
+            this.targetHumanPitchOffset = 0.0f;
+            this.humanYawOffset *= 0.5f;
+            this.humanPitchOffset *= 0.5f;
+            this.humanizationTicksRemaining = 0;
+            if (Math.abs(this.humanYawOffset) < 1.0E-4f) {
+                this.humanYawOffset = 0.0f;
+            }
+            if (Math.abs(this.humanPitchOffset) < 1.0E-4f) {
+                this.humanPitchOffset = 0.0f;
+            }
+        }
+
         private double angleToMouse(float angleDelta) {
             final float minAngleChange = mouseToAngle(1);
             return Math.round(angleDelta / minAngleChange);
@@ -304,6 +354,13 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             // casting float literals to double gets us the precise values used by mc
             final double f = ctx.minecraft().options.sensitivity().get() * (double) 0.6f + (double) 0.2f;
             return (float) (mouseDelta * f * f * f * 8.0d) * 0.15f; // yes, one double and one float scaling factor
+        }
+
+        private int boundedRandom(int bound) {
+            if (bound <= 1) {
+                return 0;
+            }
+            return (int) (this.rand.nextDouble() * bound);
         }
     }
 

--- a/src/main/java/baritone/behavior/LookBehavior.java
+++ b/src/main/java/baritone/behavior/LookBehavior.java
@@ -18,6 +18,8 @@
 package baritone.behavior;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
 import baritone.api.Settings;
 import baritone.api.behavior.ILookBehavior;
 import baritone.api.behavior.look.IAimProcessor;
@@ -26,6 +28,7 @@ import baritone.api.event.events.*;
 import baritone.api.utils.IPlayerContext;
 import baritone.api.utils.Rotation;
 import baritone.behavior.look.ForkableRandom;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 
 import java.util.ArrayDeque;
@@ -318,9 +321,15 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
             }
 
             if (this.humanizationTicksRemaining-- <= 0) {
-                final float maxAngle = Math.max(0.0f, settings.antiCheatHumanizationAngle.value);
-                this.targetHumanYawOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * maxAngle);
-                this.targetHumanPitchOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * maxAngle * 0.7f);
+                final HumanizationProfileSnapshot snapshot = resolveHumanizationSnapshot();
+                float yawAmplitude = Math.max(0.0f, settings.antiCheatHumanizationAngle.value);
+                float pitchAmplitude = yawAmplitude * 0.7f;
+                if (snapshot.hasRotationSamples()) {
+                    yawAmplitude = Math.max(yawAmplitude, (float) Math.min(10.0f, snapshot.getYawDelta().getMean() + snapshot.getYawDelta().getStdDev()));
+                    pitchAmplitude = Math.max(pitchAmplitude, (float) Math.min(10.0f, snapshot.getPitchDelta().getMean() + snapshot.getPitchDelta().getStdDev()));
+                }
+                this.targetHumanYawOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * yawAmplitude);
+                this.targetHumanPitchOffset = (float) ((this.rand.nextDouble() * 2.0 - 1.0) * pitchAmplitude);
 
                 final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
                 final int variance = Math.max(1, baseInterval);
@@ -361,6 +370,17 @@ public final class LookBehavior extends Behavior implements ILookBehavior {
                 return 0;
             }
             return (int) (this.rand.nextDouble() * bound);
+        }
+
+        private HumanizationProfileSnapshot resolveHumanizationSnapshot() {
+            if (ctx.player() == null) {
+                return HumanizationProfileSnapshot.EMPTY;
+            }
+            final IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(ctx.player());
+            if (baritone == null) {
+                return HumanizationProfileSnapshot.EMPTY;
+            }
+            return baritone.getHumanizationBehavior().snapshot();
         }
     }
 

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -57,6 +57,7 @@ public final class DefaultCommands {
                 new ExploreFilterCommand(baritone),
                 new ReloadAllCommand(baritone),
                 new SaveAllCommand(baritone),
+                new HumanizationCommand(baritone),
                 new ExploreCommand(baritone),
                 new BlacklistCommand(baritone),
                 new FindCommand(baritone),

--- a/src/main/java/baritone/command/defaults/HumanizationCommand.java
+++ b/src/main/java/baritone/command/defaults/HumanizationCommand.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.behavior.IHumanizationBehavior;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.argument.ICommandArgument;
+import baritone.api.command.exception.CommandException;
+import baritone.api.command.exception.CommandInvalidTypeException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Provides control over the adaptive humanization recorder.
+ */
+public class HumanizationCommand extends Command {
+
+    private static final List<String> ACTIONS = Arrays.asList("record", "stop", "reset", "status");
+
+    public HumanizationCommand(IBaritone baritone) {
+        super(baritone, "humanization");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        final IHumanizationBehavior behavior = this.baritone.getHumanizationBehavior();
+
+        if (!args.hasAny()) {
+            emitStatus(behavior);
+            return;
+        }
+
+        final ICommandArgument raw = args.get();
+        final String subCommand = raw.getValue().toLowerCase(Locale.ROOT);
+
+        switch (subCommand) {
+            case "record" -> {
+                behavior.startRecording();
+                logDirect("Humanization recording started. Play as you normally would to teach Baritone.");
+            }
+            case "stop" -> {
+                behavior.stopRecording();
+                logDirect(String.format(Locale.ROOT,
+                        "Recording stopped. Profile now includes %d ticks of input.",
+                        behavior.snapshot().getRecordedTicks()));
+            }
+            case "reset" -> {
+                behavior.resetProfile();
+                logDirect("Humanization profile cleared.");
+            }
+            case "status" -> emitStatus(behavior);
+            default -> throw new CommandInvalidTypeException(raw, "record / stop / reset / status", subCommand);
+        }
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) throws CommandException {
+        if (args.hasAny()) {
+            final String prefix = args.peekString().toLowerCase(Locale.ROOT);
+            return ACTIONS.stream().filter(action -> action.startsWith(prefix));
+        }
+        return ACTIONS.stream();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Control the adaptive humanization recorder.";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "#humanization record - begin recording your own inputs and block interactions.",
+                "#humanization stop - stop recording while keeping any collected samples.",
+                "#humanization reset - delete all recorded samples.",
+                "#humanization status - display recording state and sample counts."
+        );
+    }
+
+    private void emitStatus(IHumanizationBehavior behavior) {
+        final HumanizationProfileSnapshot snapshot = behavior.snapshot();
+        logDirect(String.format(Locale.ROOT, "Recording: %s", behavior.isRecording() ? "active" : "inactive"));
+        logDirect(String.format(Locale.ROOT,
+                "Ticks: %d | Movement samples: %d | Rotation samples: %d | Block breaks: %d | Block uses: %d",
+                snapshot.getRecordedTicks(),
+                snapshot.getMovementMagnitude().getCount(),
+                snapshot.getYawDelta().getCount(),
+                snapshot.getBlockBreakDuration().getCount(),
+                snapshot.getBlockPlaceInterval().getCount()));
+    }
+}

--- a/src/main/java/baritone/humanization/HumanizationProfile.java
+++ b/src/main/java/baritone/humanization/HumanizationProfile.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.humanization;
+
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
+
+/**
+ * Mutable container that aggregates player telemetry for the humanization layer.
+ */
+public final class HumanizationProfile {
+
+    private final RunningStat movementMagnitude = new RunningStat();
+    private final RunningStat strafeDelta = new RunningStat();
+    private final RunningStat forwardDelta = new RunningStat();
+    private final RunningStat yawDelta = new RunningStat();
+    private final RunningStat pitchDelta = new RunningStat();
+    private final RunningStat sprintReactionTicks = new RunningStat();
+    private final RunningStat jumpReactionTicks = new RunningStat();
+    private final RunningStat blockBreakDowntime = new RunningStat();
+    private final RunningStat blockBreakDuration = new RunningStat();
+    private final RunningStat blockPlaceInterval = new RunningStat();
+    private long recordedTicks;
+
+    public void addMovementSample(double strafe, double forward) {
+        double magnitude = Math.sqrt(strafe * strafe + forward * forward);
+        this.movementMagnitude.add(magnitude);
+        this.strafeDelta.add(strafe);
+        this.forwardDelta.add(forward);
+    }
+
+    public void addRotationSample(double yaw, double pitch) {
+        this.yawDelta.add(yaw);
+        this.pitchDelta.add(pitch);
+    }
+
+    public void addSprintReaction(int ticks) {
+        if (ticks >= 0) {
+            this.sprintReactionTicks.add(ticks);
+        }
+    }
+
+    public void addJumpReaction(int ticks) {
+        if (ticks >= 0) {
+            this.jumpReactionTicks.add(ticks);
+        }
+    }
+
+    public void addBlockBreakDowntime(long ticks) {
+        if (ticks >= 0) {
+            this.blockBreakDowntime.add(ticks);
+        }
+    }
+
+    public void addBlockBreakDuration(long ticks) {
+        if (ticks >= 0) {
+            this.blockBreakDuration.add(ticks);
+        }
+    }
+
+    public void addBlockPlaceInterval(long ticks) {
+        if (ticks >= 0) {
+            this.blockPlaceInterval.add(ticks);
+        }
+    }
+
+    public void incrementRecordedTicks() {
+        this.recordedTicks++;
+    }
+
+    public long getRecordedTicks() {
+        return this.recordedTicks;
+    }
+
+    public void clear() {
+        this.movementMagnitude.clear();
+        this.strafeDelta.clear();
+        this.forwardDelta.clear();
+        this.yawDelta.clear();
+        this.pitchDelta.clear();
+        this.sprintReactionTicks.clear();
+        this.jumpReactionTicks.clear();
+        this.blockBreakDowntime.clear();
+        this.blockBreakDuration.clear();
+        this.blockPlaceInterval.clear();
+        this.recordedTicks = 0L;
+    }
+
+    public HumanizationProfileSnapshot snapshot() {
+        return new HumanizationProfileSnapshot(
+                this.movementMagnitude.snapshot(),
+                this.strafeDelta.snapshot(),
+                this.forwardDelta.snapshot(),
+                this.yawDelta.snapshot(),
+                this.pitchDelta.snapshot(),
+                this.sprintReactionTicks.snapshot(),
+                this.jumpReactionTicks.snapshot(),
+                this.blockBreakDowntime.snapshot(),
+                this.blockBreakDuration.snapshot(),
+                this.blockPlaceInterval.snapshot(),
+                this.recordedTicks
+        );
+    }
+}

--- a/src/main/java/baritone/humanization/RunningStat.java
+++ b/src/main/java/baritone/humanization/RunningStat.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.humanization;
+
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
+
+/**
+ * Online variance accumulator used to capture statistics about player actions.
+ */
+public final class RunningStat {
+
+    private long samples;
+    private double mean;
+    private double m2;
+    private double min;
+    private double max;
+
+    public RunningStat() {
+        this.samples = 0L;
+        this.mean = 0.0;
+        this.m2 = 0.0;
+        this.min = Double.NaN;
+        this.max = Double.NaN;
+    }
+
+    public void add(double value) {
+        this.samples++;
+        double delta = value - this.mean;
+        this.mean += delta / this.samples;
+        double delta2 = value - this.mean;
+        this.m2 += delta * delta2;
+        if (Double.isNaN(this.min) || value < this.min) {
+            this.min = value;
+        }
+        if (Double.isNaN(this.max) || value > this.max) {
+            this.max = value;
+        }
+    }
+
+    public void clear() {
+        this.samples = 0L;
+        this.mean = 0.0;
+        this.m2 = 0.0;
+        this.min = Double.NaN;
+        this.max = Double.NaN;
+    }
+
+    public boolean hasSamples() {
+        return this.samples > 0L;
+    }
+
+    public long getSamples() {
+        return this.samples;
+    }
+
+    public double getMean() {
+        return this.samples > 0 ? this.mean : 0.0;
+    }
+
+    public double getStdDev() {
+        return this.samples > 1 ? Math.sqrt(this.m2 / (this.samples - 1)) : 0.0;
+    }
+
+    public double getMin() {
+        return this.min;
+    }
+
+    public double getMax() {
+        return this.max;
+    }
+
+    public HumanizationProfileSnapshot.RunningStat snapshot() {
+        return new HumanizationProfileSnapshot.RunningStat(
+                this.samples,
+                getMean(),
+                getStdDev(),
+                this.min,
+                this.max
+        );
+    }
+}

--- a/src/main/java/baritone/utils/BlockBreakHelper.java
+++ b/src/main/java/baritone/utils/BlockBreakHelper.java
@@ -18,11 +18,15 @@
 package baritone.utils;
 
 import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
 import baritone.api.utils.IPlayerContext;
 import baritone.utils.accessor.IPlayerControllerMP;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
+
+import java.util.Random;
 
 /**
  * @author Brady
@@ -35,6 +39,7 @@ public final class BlockBreakHelper {
     private final IPlayerContext ctx;
     private boolean wasHitting;
     private int breakDelayTimer = 0;
+    private final Random humanRandom = new Random();
 
     BlockBreakHelper(IPlayerContext ctx) {
         this.ctx = ctx;
@@ -70,6 +75,7 @@ public final class BlockBreakHelper {
                 if (ctx.playerController().hasBrokenBlock()) { // block broken this tick
                     // break delay timer only applies for multi-tick block breaks like vanilla
                     breakDelayTimer = BaritoneAPI.getSettings().blockBreakSpeed.value - BASE_BREAK_DELAY;
+                    breakDelayTimer += sampleHumanBreakDelay();
                     // must reset controller's destroy delay to prevent the client from delaying itself unnecessarily
                     ((IPlayerControllerMP) ctx.minecraft().gameMode).setDestroyDelay(0);
                 }
@@ -83,5 +89,31 @@ public final class BlockBreakHelper {
         } else {
             wasHitting = false;
         }
+    }
+
+    private int sampleHumanBreakDelay() {
+        if (!shouldHumanize()) {
+            return 0;
+        }
+        final IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(ctx.player());
+        if (baritone == null) {
+            return 0;
+        }
+        final HumanizationProfileSnapshot snapshot = baritone.getHumanizationBehavior().snapshot();
+        final HumanizationProfileSnapshot.RunningStat downtime = snapshot.getBlockBreakDowntime();
+        if (!downtime.hasSamples()) {
+            return 0;
+        }
+        double mean = Math.max(0.0, downtime.getMean());
+        double std = downtime.getStdDev();
+        double sample = std > 0.0 ? humanRandom.nextGaussian() * std + mean : mean;
+        if (downtime.getCount() < 3) {
+            sample = mean;
+        }
+        return Math.max(0, (int) Math.round(sample));
+    }
+
+    private boolean shouldHumanize() {
+        return BaritoneAPI.getSettings().antiCheatCompatibility.value && BaritoneAPI.getSettings().antiCheatHumanization.value && ctx.player() != null;
     }
 }

--- a/src/main/java/baritone/utils/BlockPlaceHelper.java
+++ b/src/main/java/baritone/utils/BlockPlaceHelper.java
@@ -18,11 +18,16 @@
 package baritone.utils;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
 import baritone.api.utils.IPlayerContext;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
+
+import java.util.Random;
 
 public class BlockPlaceHelper {
     // base ticks between places caused by tick logic
@@ -30,6 +35,7 @@ public class BlockPlaceHelper {
 
     private final IPlayerContext ctx;
     private int rightClickTimer;
+    private final Random humanRandom = new Random();
 
     BlockPlaceHelper(IPlayerContext playerContext) {
         this.ctx = playerContext;
@@ -45,6 +51,7 @@ public class BlockPlaceHelper {
             return;
         }
         rightClickTimer = Baritone.settings().rightClickSpeed.value - BASE_PLACE_DELAY;
+        rightClickTimer += sampleHumanPlaceDelay();
         for (InteractionHand hand : InteractionHand.values()) {
             if (ctx.playerController().processRightClickBlock(ctx.player(), ctx.world(), hand, (BlockHitResult) mouseOver) == InteractionResult.SUCCESS) {
                 ctx.player().swing(hand);
@@ -54,5 +61,31 @@ public class BlockPlaceHelper {
                 return;
             }
         }
+    }
+
+    private int sampleHumanPlaceDelay() {
+        if (!shouldHumanize()) {
+            return 0;
+        }
+        final IBaritone baritone = BaritoneAPI.getProvider().getBaritoneForPlayer(ctx.player());
+        if (baritone == null) {
+            return 0;
+        }
+        final HumanizationProfileSnapshot snapshot = baritone.getHumanizationBehavior().snapshot();
+        final HumanizationProfileSnapshot.RunningStat interval = snapshot.getBlockPlaceInterval();
+        if (!interval.hasSamples()) {
+            return 0;
+        }
+        double mean = Math.max(0.0, interval.getMean());
+        double std = interval.getStdDev();
+        double sample = std > 0.0 ? humanRandom.nextGaussian() * std + mean : mean;
+        if (interval.getCount() < 3) {
+            sample = mean;
+        }
+        return Math.max(0, (int) Math.round(sample));
+    }
+
+    private boolean shouldHumanize() {
+        return Baritone.settings().antiCheatCompatibility.value && Baritone.settings().antiCheatHumanization.value && ctx.player() != null;
     }
 }

--- a/src/main/java/baritone/utils/PlayerMovementInput.java
+++ b/src/main/java/baritone/utils/PlayerMovementInput.java
@@ -19,6 +19,7 @@ package baritone.utils;
 
 import baritone.Baritone;
 import baritone.api.Settings;
+import baritone.api.behavior.humanization.HumanizationProfileSnapshot;
 import baritone.api.utils.input.Input;
 import net.minecraft.client.player.ClientInput;
 import net.minecraft.world.phys.Vec2;
@@ -79,9 +80,13 @@ public class PlayerMovementInput extends ClientInput {
         final Settings settings = Baritone.settings();
         final boolean humanize = settings.antiCheatCompatibility.value && settings.antiCheatHumanization.value;
 
+        final HumanizationProfileSnapshot snapshot = humanize
+                ? handler.baritone.getHumanizationBehavior().snapshot()
+                : HumanizationProfileSnapshot.EMPTY;
+
         if (humanize) {
-            movement = applyMovementHumanization(movement, settings);
-            jumping = applyJumpHumanization(jumping, settings);
+            movement = applyMovementHumanization(movement, settings, snapshot);
+            jumping = applyJumpHumanization(jumping, settings, snapshot);
         } else {
             resetMovementHumanization();
         }
@@ -90,7 +95,7 @@ public class PlayerMovementInput extends ClientInput {
 
         boolean sprinting = handler.isInputForcedDown(Input.SPRINT);
         if (humanize) {
-            sprinting = applySprintHumanization(sprinting, settings);
+            sprinting = applySprintHumanization(sprinting, settings, snapshot);
         } else {
             resetSprintHumanization();
         }
@@ -98,16 +103,18 @@ public class PlayerMovementInput extends ClientInput {
         this.keyPresses = new net.minecraft.world.entity.player.Input(up, down, left, right, jumping, sneaking, sprinting);
     }
 
-    private Vec2 applyMovementHumanization(Vec2 base, Settings settings) {
+    private Vec2 applyMovementHumanization(Vec2 base, Settings settings, HumanizationProfileSnapshot snapshot) {
         if (Math.abs(base.x) < 1.0E-3f && Math.abs(base.y) < 1.0E-3f) {
             fadeMovementNoise();
             return base;
         }
 
         if (this.noiseTicksRemaining-- <= 0) {
-            final float maxMovement = Math.max(0.0f, settings.antiCheatHumanizationMovement.value);
-            this.targetStrafeNoise = randomInRange(maxMovement);
-            this.targetForwardNoise = randomInRange(maxMovement);
+            final float baseMovement = Math.max(0.0f, settings.antiCheatHumanizationMovement.value);
+            final float strafeAmplitude = resolveMovementAmplitude(baseMovement, snapshot.getStrafeDelta());
+            final float forwardAmplitude = resolveMovementAmplitude(baseMovement, snapshot.getForwardDelta());
+            this.targetStrafeNoise = randomInRange(strafeAmplitude);
+            this.targetForwardNoise = randomInRange(forwardAmplitude);
 
             final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
             final int variance = Math.max(1, baseInterval);
@@ -122,11 +129,11 @@ public class PlayerMovementInput extends ClientInput {
         return new Vec2(strafe, forward);
     }
 
-    private boolean applySprintHumanization(boolean sprinting, Settings settings) {
+    private boolean applySprintHumanization(boolean sprinting, Settings settings, HumanizationProfileSnapshot snapshot) {
         if (sprinting) {
             if (!this.lastSprintRequest) {
-                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
-                this.sprintDelayTicks = 1 + this.humanRandom.nextInt(Math.max(1, baseInterval / 2));
+                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value / 2);
+                this.sprintDelayTicks = sampleReactionDelay(snapshot.getSprintReactionTicks(), baseInterval, false);
             }
         } else {
             this.sprintDelayTicks = 0;
@@ -142,11 +149,11 @@ public class PlayerMovementInput extends ClientInput {
         return sprinting;
     }
 
-    private boolean applyJumpHumanization(boolean jumping, Settings settings) {
+    private boolean applyJumpHumanization(boolean jumping, Settings settings, HumanizationProfileSnapshot snapshot) {
         if (jumping) {
             if (!this.lastJumpRequest) {
-                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value / 2);
-                this.jumpDelayTicks = baseInterval > 0 ? this.humanRandom.nextInt(baseInterval + 1) : 0;
+                final int baseInterval = Math.max(0, settings.antiCheatHumanizationInterval.value / 2);
+                this.jumpDelayTicks = sampleReactionDelay(snapshot.getJumpReactionTicks(), baseInterval, true);
             }
         } else {
             this.jumpDelayTicks = 0;
@@ -192,6 +199,34 @@ public class PlayerMovementInput extends ClientInput {
             return 0.0f;
         }
         return (float) ((this.humanRandom.nextDouble() * 2.0 - 1.0) * max);
+    }
+
+    private float resolveMovementAmplitude(float base, HumanizationProfileSnapshot.RunningStat stat) {
+        float amplitude = base;
+        if (stat.hasSamples()) {
+            double target = stat.getMean() + stat.getStdDev() * 0.5;
+            amplitude = Math.max(amplitude, (float) Math.min(0.75f, Math.abs(target)));
+        }
+        return amplitude;
+    }
+
+    private int sampleReactionDelay(HumanizationProfileSnapshot.RunningStat stat, int fallbackRange, boolean allowZero) {
+        if (stat.hasSamples()) {
+            double mean = Math.max(0.0, stat.getMean());
+            double std = stat.getStdDev();
+            double sample = std > 0.0 ? this.humanRandom.nextGaussian() * std + mean : mean;
+            if (stat.getCount() < 3) {
+                sample = mean;
+            }
+            return Math.max(0, (int) Math.round(sample));
+        }
+        if (fallbackRange <= 0) {
+            return allowZero ? 0 : 0;
+        }
+        if (allowZero) {
+            return this.humanRandom.nextInt(fallbackRange + 1);
+        }
+        return this.humanRandom.nextInt(Math.max(1, fallbackRange)) + 1;
     }
 
     private static float clamp(float value, float min, float max) {

--- a/src/main/java/baritone/utils/PlayerMovementInput.java
+++ b/src/main/java/baritone/utils/PlayerMovementInput.java
@@ -17,13 +17,27 @@
 
 package baritone.utils;
 
+import baritone.Baritone;
+import baritone.api.Settings;
 import baritone.api.utils.input.Input;
 import net.minecraft.client.player.ClientInput;
 import net.minecraft.world.phys.Vec2;
 
+import java.util.Random;
+
 public class PlayerMovementInput extends ClientInput {
 
     private final InputOverrideHandler handler;
+    private final Random humanRandom = new Random();
+    private float strafeNoise;
+    private float forwardNoise;
+    private float targetStrafeNoise;
+    private float targetForwardNoise;
+    private int noiseTicksRemaining;
+    private boolean lastSprintRequest;
+    private int sprintDelayTicks;
+    private boolean lastJumpRequest;
+    private int jumpDelayTicks;
 
     PlayerMovementInput(InputOverrideHandler handler) {
         this.handler = handler;
@@ -60,10 +74,133 @@ public class PlayerMovementInput extends ClientInput {
             leftImpulse *= 0.3D;
             forwardImpulse *= 0.3D;
         }
-        this.moveVector = new Vec2(leftImpulse, forwardImpulse);
+        Vec2 movement = new Vec2(leftImpulse, forwardImpulse);
+
+        final Settings settings = Baritone.settings();
+        final boolean humanize = settings.antiCheatCompatibility.value && settings.antiCheatHumanization.value;
+
+        if (humanize) {
+            movement = applyMovementHumanization(movement, settings);
+            jumping = applyJumpHumanization(jumping, settings);
+        } else {
+            resetMovementHumanization();
+        }
+
+        this.moveVector = movement;
 
         boolean sprinting = handler.isInputForcedDown(Input.SPRINT);
+        if (humanize) {
+            sprinting = applySprintHumanization(sprinting, settings);
+        } else {
+            resetSprintHumanization();
+        }
 
         this.keyPresses = new net.minecraft.world.entity.player.Input(up, down, left, right, jumping, sneaking, sprinting);
+    }
+
+    private Vec2 applyMovementHumanization(Vec2 base, Settings settings) {
+        if (Math.abs(base.x) < 1.0E-3f && Math.abs(base.y) < 1.0E-3f) {
+            fadeMovementNoise();
+            return base;
+        }
+
+        if (this.noiseTicksRemaining-- <= 0) {
+            final float maxMovement = Math.max(0.0f, settings.antiCheatHumanizationMovement.value);
+            this.targetStrafeNoise = randomInRange(maxMovement);
+            this.targetForwardNoise = randomInRange(maxMovement);
+
+            final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
+            final int variance = Math.max(1, baseInterval);
+            this.noiseTicksRemaining = baseInterval / 2 + this.humanRandom.nextInt(variance);
+        }
+
+        this.strafeNoise += (this.targetStrafeNoise - this.strafeNoise) * 0.4f;
+        this.forwardNoise += (this.targetForwardNoise - this.forwardNoise) * 0.4f;
+
+        final float strafe = clamp(base.x + this.strafeNoise, -1.0f, 1.0f);
+        final float forward = clamp(base.y + this.forwardNoise, -1.0f, 1.0f);
+        return new Vec2(strafe, forward);
+    }
+
+    private boolean applySprintHumanization(boolean sprinting, Settings settings) {
+        if (sprinting) {
+            if (!this.lastSprintRequest) {
+                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value);
+                this.sprintDelayTicks = 1 + this.humanRandom.nextInt(Math.max(1, baseInterval / 2));
+            }
+        } else {
+            this.sprintDelayTicks = 0;
+        }
+
+        this.lastSprintRequest = sprinting;
+
+        if (this.sprintDelayTicks > 0) {
+            this.sprintDelayTicks--;
+            return false;
+        }
+
+        return sprinting;
+    }
+
+    private boolean applyJumpHumanization(boolean jumping, Settings settings) {
+        if (jumping) {
+            if (!this.lastJumpRequest) {
+                final int baseInterval = Math.max(1, settings.antiCheatHumanizationInterval.value / 2);
+                this.jumpDelayTicks = baseInterval > 0 ? this.humanRandom.nextInt(baseInterval + 1) : 0;
+            }
+        } else {
+            this.jumpDelayTicks = 0;
+        }
+
+        this.lastJumpRequest = jumping;
+
+        if (this.jumpDelayTicks > 0) {
+            this.jumpDelayTicks--;
+            return false;
+        }
+
+        return jumping;
+    }
+
+    private void resetMovementHumanization() {
+        fadeMovementNoise();
+        this.noiseTicksRemaining = 0;
+    }
+
+    private void resetSprintHumanization() {
+        this.lastSprintRequest = false;
+        this.sprintDelayTicks = 0;
+        this.lastJumpRequest = false;
+        this.jumpDelayTicks = 0;
+    }
+
+    private void fadeMovementNoise() {
+        this.targetStrafeNoise = 0.0f;
+        this.targetForwardNoise = 0.0f;
+        this.strafeNoise *= 0.6f;
+        this.forwardNoise *= 0.6f;
+        if (Math.abs(this.strafeNoise) < 1.0E-4f) {
+            this.strafeNoise = 0.0f;
+        }
+        if (Math.abs(this.forwardNoise) < 1.0E-4f) {
+            this.forwardNoise = 0.0f;
+        }
+    }
+
+    private float randomInRange(float max) {
+        if (max <= 0.0f) {
+            return 0.0f;
+        }
+        return (float) ((this.humanRandom.nextDouble() * 2.0 - 1.0) * max);
+    }
+
+    private static float clamp(float value, float min, float max) {
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
+        return value;
     }
 }


### PR DESCRIPTION
## Summary
- add tunable anti-cheat humanization settings alongside the existing compatibility toggle
- apply gradual rotation drift when anti-cheat compatibility is active so server-facing angles look more human
- humanize movement inputs by jittering analog impulses and delaying sprint/jump toggles to mimic player behavior

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_b_68d78ad546d4832f8701394b7e9d9110