### PR TITLE
Add seed predictive planning storage and macro planner skeleton

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -24,6 +24,7 @@ import baritone.api.cache.IWorldProvider;
 import baritone.api.command.manager.ICommandManager;
 import baritone.api.event.listener.IEventBus;
 import baritone.api.pathing.calc.IPathingControlManager;
+import baritone.api.pathing.seed.ISeedPathing;
 import baritone.api.process.*;
 import baritone.api.selection.ISelectionManager;
 import baritone.api.utils.IInputOverrideHandler;
@@ -150,4 +151,9 @@ public interface IBaritone {
      * Open click
      */
     void openClick();
+
+    /**
+     * @return The seed-based predictive pathing controller for this baritone instance.
+     */
+    ISeedPathing getSeedPathing();
 }

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -154,6 +154,22 @@ public final class Settings {
     public final Setting<Boolean> allowWaterBucketFall = new Setting<>(true);
 
     /**
+     * Enable the experimental seed-based macro planner that predicts terrain from a configured seed.
+     * Disabled by default so existing behavior is unchanged unless explicitly toggled.
+     */
+    public final Setting<Boolean> seedBasedPrediction = new Setting<>(false);
+
+    /**
+     * The last configured world seed for predictive planning. Requires {@link #seedPredictionSeedConfigured} to be true.
+     */
+    public final Setting<Long> seedPredictionSeed = new Setting<>(0L);
+
+    /**
+     * Tracks whether a predictive planning seed has been explicitly provided by the user.
+     */
+    public final Setting<Boolean> seedPredictionSeedConfigured = new Setting<>(false);
+
+    /**
      * Allow Baritone to assume it can walk on still water just like any other block.
      * This functionality is assumed to be provided by a separate library that might have imported Baritone.
      * <p>

--- a/src/api/java/baritone/api/pathing/seed/ISeedPathing.java
+++ b/src/api/java/baritone/api/pathing/seed/ISeedPathing.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.pathing.seed;
+
+import java.util.OptionalLong;
+
+/**
+ * Public API for controlling seed-based predictive pathing.
+ */
+public interface ISeedPathing {
+
+    /**
+     * @return the configured seed if one has been set.
+     */
+    OptionalLong seed();
+
+    /**
+     * @return {@code true} if a seed has been configured for predictive planning.
+     */
+    boolean hasSeed();
+
+    /**
+     * Configure the seed that should be used for predictive planning.
+     *
+     * @param seed the world seed to use
+     */
+    void setSeed(long seed);
+
+    /**
+     * Clear the configured seed, disabling predictive planning until a new seed is provided.
+     */
+    void clearSeed();
+
+    /**
+     * @return {@code true} if predictive planning is currently active and will be applied to path calculations.
+     */
+    boolean isPredictionEnabled();
+
+    /**
+     * Enable or disable predictive planning. Implementations may return {@code false} when enabling without a configured seed.
+     *
+     * @param enabled whether predictive planning should be active
+     * @return {@code true} if predictive planning will be active after applying the requested state
+     */
+    boolean setPredictionEnabled(boolean enabled);
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -24,6 +24,7 @@ import baritone.api.behavior.IBehavior;
 import baritone.api.event.listener.IEventBus;
 import baritone.api.process.IBaritoneProcess;
 import baritone.api.process.IElytraProcess;
+import baritone.api.pathing.seed.ISeedPathing;
 import baritone.api.utils.IPlayerContext;
 import baritone.behavior.*;
 import baritone.cache.WorldProvider;
@@ -36,6 +37,7 @@ import baritone.utils.GuiClick;
 import baritone.utils.InputOverrideHandler;
 import baritone.utils.PathingControlManager;
 import baritone.utils.player.BaritonePlayerContext;
+import baritone.pathing.seed.SeedPredictionService;
 import net.minecraft.client.Minecraft;
 
 import java.io.IOException;
@@ -86,6 +88,8 @@ public class Baritone implements IBaritone {
     private final SelectionManager selectionManager;
     private final CommandManager commandManager;
 
+    private final SeedPredictionService seedPrediction;
+
     private final IPlayerContext playerContext;
     private final WorldProvider worldProvider;
 
@@ -131,6 +135,8 @@ public class Baritone implements IBaritone {
         this.worldProvider = new WorldProvider(this);
         this.selectionManager = new SelectionManager(this);
         this.commandManager = new CommandManager(this);
+        this.seedPrediction = new SeedPredictionService(this);
+        this.gameEventHandler.registerEventListener(this.seedPrediction);
     }
 
     public void registerBehavior(IBehavior behavior) {
@@ -245,6 +251,15 @@ public class Baritone implements IBaritone {
     @Override
     public IElytraProcess getElytraProcess() {
         return this.elytraProcess;
+    }
+
+    @Override
+    public ISeedPathing getSeedPathing() {
+        return this.seedPrediction;
+    }
+
+    public SeedPredictionService getSeedPrediction() {
+        return this.seedPrediction;
     }
 
     @Override

--- a/src/main/java/baritone/behavior/PathingBehavior.java
+++ b/src/main/java/baritone/behavior/PathingBehavior.java
@@ -572,6 +572,7 @@ public final class PathingBehavior extends Behavior implements IPathingBehavior,
         if (feet.getY() == realStart.getY() && Math.abs(sub.getX()) <= 1 && Math.abs(sub.getZ()) <= 1) {
             realStart = feet;
         }
+        baritone.getSeedPrediction().applySeedFavoring(realStart, transformed, favoring, context, previous);
         return new AStarPathFinder(realStart, start.getX(), start.getY(), start.getZ(), transformed, favoring, context);
 
     }

--- a/src/main/java/baritone/cache/seed/BlockCompressor.java
+++ b/src/main/java/baritone/cache/seed/BlockCompressor.java
@@ -1,0 +1,27 @@
+package baritone.cache.seed;
+
+/**
+ * Simple pluggable block compressor used to pack individual chunk fields.
+ * Implementations can wrap native libraries (LZ4, Zstd, etc) while the planner
+ * only depends on this small API.
+ */
+public interface BlockCompressor {
+
+    byte[] compress(byte[] data);
+
+    byte[] decompress(byte[] data, int expectedLength);
+
+    static BlockCompressor noCompression() {
+        return new BlockCompressor() {
+            @Override
+            public byte[] compress(byte[] data) {
+                return data;
+            }
+
+            @Override
+            public byte[] decompress(byte[] data, int expectedLength) {
+                return data;
+            }
+        };
+    }
+}

--- a/src/main/java/baritone/cache/seed/ChunkField.java
+++ b/src/main/java/baritone/cache/seed/ChunkField.java
@@ -1,0 +1,25 @@
+package baritone.cache.seed;
+
+/**
+ * Logical fields stored inside a chunk summary blob. Each field is compressed as an
+ * independent block so that readers can lazily materialize only the data that a query
+ * needs.
+ */
+public enum ChunkField {
+    PASSABILITY(1 << 0),
+    HEIGHTS(1 << 1),
+    CAVES(1 << 2),
+    ORES(1 << 3),
+    STRUCTURES(1 << 4),
+    EXTRAS(1 << 5);
+
+    private final int bit;
+
+    ChunkField(int bit) {
+        this.bit = bit;
+    }
+
+    public int bit() {
+        return bit;
+    }
+}

--- a/src/main/java/baritone/cache/seed/ChunkSummaryHeader.java
+++ b/src/main/java/baritone/cache/seed/ChunkSummaryHeader.java
@@ -1,0 +1,56 @@
+package baritone.cache.seed;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Small bitfield describing which summaries are present for a chunk.
+ */
+public final class ChunkSummaryHeader {
+
+    private static final byte VERSION_MASK = (byte) 0xC0;
+    private static final byte FIELD_MASK = 0x3F;
+
+    private final byte mask;
+
+    private ChunkSummaryHeader(byte mask) {
+        this.mask = mask;
+    }
+
+    public static ChunkSummaryHeader of(Set<ChunkField> fields) {
+        byte mask = 0;
+        for (ChunkField field : fields) {
+            mask |= field.bit();
+        }
+        return new ChunkSummaryHeader(mask);
+    }
+
+    public static ChunkSummaryHeader empty() {
+        return new ChunkSummaryHeader((byte) 0);
+    }
+
+    public static ChunkSummaryHeader fromByte(byte value) {
+        if ((value & VERSION_MASK) != 0) {
+            throw new IllegalArgumentException("Unknown chunk summary header version " + value);
+        }
+        return new ChunkSummaryHeader((byte) (value & FIELD_MASK));
+    }
+
+    public byte toByte() {
+        return mask;
+    }
+
+    public boolean hasField(ChunkField field) {
+        return (mask & field.bit()) != 0;
+    }
+
+    public Set<ChunkField> fields() {
+        EnumSet<ChunkField> set = EnumSet.noneOf(ChunkField.class);
+        for (ChunkField field : ChunkField.values()) {
+            if (hasField(field)) {
+                set.add(field);
+            }
+        }
+        return set;
+    }
+}

--- a/src/main/java/baritone/cache/seed/ChunkSummaryPacker.java
+++ b/src/main/java/baritone/cache/seed/ChunkSummaryPacker.java
@@ -1,0 +1,77 @@
+package baritone.cache.seed;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.Map;
+
+import baritone.utils.io.VarIntUtils;
+
+/**
+ * Packs and unpacks {@link ChunkSummaryRecord} instances to the compact on-disk representation.
+ */
+public final class ChunkSummaryPacker {
+
+    private ChunkSummaryPacker() {
+    }
+
+    public static EncodedChunk encode(ChunkSummaryRecord record, BlockCompressor compressor) {
+        Map<ChunkField, FieldBlock> blocks = new EnumMap<>(ChunkField.class);
+        for (ChunkField field : record.header().fields()) {
+            byte[] raw;
+            switch (field) {
+                case PASSABILITY:
+                    raw = record.passability();
+                    break;
+                case HEIGHTS:
+                    raw = record.heights().toByteArray();
+                    break;
+                case CAVES:
+                    raw = record.caveBands();
+                    break;
+                case ORES:
+                    raw = record.oreBands();
+                    break;
+                case STRUCTURES:
+                    raw = record.structures();
+                    break;
+                case EXTRAS:
+                    raw = record.extras();
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown field " + field);
+            }
+            byte[] compressed = compressor.compress(raw);
+            blocks.put(field, new FieldBlock(compressed, raw.length));
+        }
+
+        ByteArrayOutputStream headerOut = new ByteArrayOutputStream();
+        headerOut.write(record.header().toByte());
+        for (ChunkField field : ChunkField.values()) {
+            if (record.header().hasField(field)) {
+                FieldBlock block = blocks.get(field);
+                VarIntUtils.writeUnsigned(headerOut, block.compressed.length);
+                VarIntUtils.writeUnsigned(headerOut, block.rawLength);
+            }
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.writeBytes(headerOut.toByteArray());
+        for (ChunkField field : ChunkField.values()) {
+            if (record.header().hasField(field)) {
+                out.writeBytes(blocks.get(field).compressed);
+            }
+        }
+        return new EncodedChunk(out.toByteArray(), record.microIndex());
+    }
+
+    public static ChunkSummaryRecordView view(ByteBuffer buffer) {
+        return new ChunkSummaryRecordView(buffer.slice());
+    }
+
+    public record EncodedChunk(byte[] payload, byte microIndex) {
+    }
+
+    private record FieldBlock(byte[] compressed, int rawLength) {
+    }
+}

--- a/src/main/java/baritone/cache/seed/ChunkSummaryRecord.java
+++ b/src/main/java/baritone/cache/seed/ChunkSummaryRecord.java
@@ -1,0 +1,170 @@
+package baritone.cache.seed;
+
+import java.util.BitSet;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * High level representation of a chunk summary prior to packing it into a compact byte[] blob.
+ */
+public final class ChunkSummaryRecord {
+
+    private final ChunkSummaryHeader header;
+    private final byte[] passability;
+    private final PackedHeightField heights;
+    private final byte[] caveBands;
+    private final byte[] oreBands;
+    private final byte[] structures;
+    private final byte[] extras;
+    private final byte microIndex;
+
+    private ChunkSummaryRecord(Builder builder) {
+        this.passability = builder.passability;
+        this.heights = builder.heights;
+        this.caveBands = builder.caveBands;
+        this.oreBands = builder.oreBands;
+        this.structures = builder.structures;
+        this.extras = builder.extras;
+        this.microIndex = builder.computeMicroIndex();
+        Set<ChunkField> fields = EnumSet.noneOf(ChunkField.class);
+        if (passability != null) {
+            fields.add(ChunkField.PASSABILITY);
+        }
+        if (heights != null) {
+            fields.add(ChunkField.HEIGHTS);
+        }
+        if (caveBands != null) {
+            fields.add(ChunkField.CAVES);
+        }
+        if (oreBands != null) {
+            fields.add(ChunkField.ORES);
+        }
+        if (structures != null) {
+            fields.add(ChunkField.STRUCTURES);
+        }
+        if (extras != null) {
+            fields.add(ChunkField.EXTRAS);
+        }
+        this.header = ChunkSummaryHeader.of(fields);
+    }
+
+    public ChunkSummaryHeader header() {
+        return header;
+    }
+
+    public byte[] passability() {
+        return passability;
+    }
+
+    public PackedHeightField heights() {
+        return heights;
+    }
+
+    public byte[] caveBands() {
+        return caveBands;
+    }
+
+    public byte[] oreBands() {
+        return oreBands;
+    }
+
+    public byte[] structures() {
+        return structures;
+    }
+
+    public byte[] extras() {
+        return extras;
+    }
+
+    public byte microIndex() {
+        return microIndex;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private byte[] passability;
+        private PackedHeightField heights;
+        private byte[] caveBands;
+        private byte[] oreBands;
+        private byte[] structures;
+        private byte[] extras;
+        private boolean highOre;
+        private boolean hasSurfacePortal;
+
+        private Builder() {
+        }
+
+        public Builder passability(BitSet bitset) {
+            this.passability = PassabilityField.pack(bitset);
+            return this;
+        }
+
+        public Builder passabilityBytes(byte[] packed) {
+            this.passability = Objects.requireNonNull(packed);
+            return this;
+        }
+
+        public Builder heights(PackedHeightField heights) {
+            this.heights = Objects.requireNonNull(heights);
+            return this;
+        }
+
+        public Builder caveBands(byte[] caveBands) {
+            this.caveBands = Objects.requireNonNull(caveBands);
+            return this;
+        }
+
+        public Builder oreBands(byte[] oreBands, boolean hasHighOre) {
+            this.oreBands = Objects.requireNonNull(oreBands);
+            this.highOre = hasHighOre;
+            return this;
+        }
+
+        public Builder structures(byte[] structures) {
+            this.structures = Objects.requireNonNull(structures);
+            return this;
+        }
+
+        public Builder extras(byte[] extras) {
+            this.extras = Objects.requireNonNull(extras);
+            return this;
+        }
+
+        public Builder surfacePortal(boolean value) {
+            this.hasSurfacePortal = value;
+            return this;
+        }
+
+        public ChunkSummaryRecord build() {
+            return new ChunkSummaryRecord(this);
+        }
+
+        private byte computeMicroIndex() {
+            byte value = 0;
+            if (caveBands != null && VerticalBandField.hasAnyEncoded(caveBands)) {
+                value |= MicroIndex.HAS_CAVE.bit();
+            }
+            if (structures != null && structures.length > 0) {
+                value |= MicroIndex.HAS_STRUCTURE.bit();
+            }
+            if (highOre) {
+                value |= MicroIndex.HAS_HIGH_ORE.bit();
+            }
+            if (heights != null && heights.isTruncated()) {
+                value |= MicroIndex.HEIGHT_TRUNCATED.bit();
+            }
+            if (hasSurfacePortal) {
+                value |= MicroIndex.HAS_SURFACE_PORTAL.bit();
+            }
+            if (passability != null && PassabilityField.hasAnyPassable(passability)) {
+                value |= MicroIndex.HAS_PASSABLE_SURFACE.bit();
+            }
+            return value;
+        }
+    }
+}

--- a/src/main/java/baritone/cache/seed/ChunkSummaryRecordView.java
+++ b/src/main/java/baritone/cache/seed/ChunkSummaryRecordView.java
@@ -1,0 +1,71 @@
+package baritone.cache.seed;
+
+import baritone.utils.io.VarIntUtils;
+
+import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Lightweight parsed view over a serialized chunk record.
+ */
+public final class ChunkSummaryRecordView {
+
+    private final ByteBuffer payload;
+    private final ChunkSummaryHeader header;
+    private final Map<ChunkField, FieldEntry> fields;
+
+    ChunkSummaryRecordView(ByteBuffer payload) {
+        this.payload = payload.slice();
+        ByteBuffer cursor = this.payload.duplicate();
+        byte headerByte = cursor.get();
+        this.header = ChunkSummaryHeader.fromByte(headerByte);
+        this.fields = new EnumMap<>(ChunkField.class);
+        for (ChunkField field : ChunkField.values()) {
+            if (header.hasField(field)) {
+                int compressedLength = VarIntUtils.readUnsigned(cursor);
+                int rawLength = VarIntUtils.readUnsigned(cursor);
+                fields.put(field, new FieldEntry(compressedLength, rawLength));
+            }
+        }
+        int headerSize = cursor.position();
+        int offset = 0;
+        for (ChunkField field : ChunkField.values()) {
+            FieldEntry entry = fields.get(field);
+            if (entry != null) {
+                fields.put(field, entry.withOffset(headerSize + offset));
+                offset += entry.compressedLength;
+            }
+        }
+    }
+
+    public ChunkSummaryHeader header() {
+        return header;
+    }
+
+    public boolean hasField(ChunkField field) {
+        return header.hasField(field);
+    }
+
+    public byte[] readField(ChunkField field, BlockCompressor compressor) {
+        FieldEntry entry = fields.get(field);
+        if (entry == null) {
+            return null;
+        }
+        ByteBuffer dup = payload.duplicate();
+        dup.position(entry.offset);
+        byte[] compressed = new byte[entry.compressedLength];
+        dup.get(compressed);
+        return compressor.decompress(compressed, entry.rawLength);
+    }
+
+    private record FieldEntry(int compressedLength, int rawLength, int offset) {
+        FieldEntry(int compressedLength, int rawLength) {
+            this(compressedLength, rawLength, -1);
+        }
+
+        FieldEntry withOffset(int offset) {
+            return new FieldEntry(compressedLength, rawLength, offset);
+        }
+    }
+}

--- a/src/main/java/baritone/cache/seed/DeflateBlockCompressor.java
+++ b/src/main/java/baritone/cache/seed/DeflateBlockCompressor.java
@@ -1,0 +1,60 @@
+package baritone.cache.seed;
+
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+/**
+ * CPU friendly fallback compressor that uses the JDK's {@link Deflater}. It keeps the
+ * block compression API pluggable so that faster LZ4/Zstd implementations can be
+ * swapped in without touching the planner code.
+ */
+public final class DeflateBlockCompressor implements BlockCompressor {
+
+    private final int level;
+
+    public DeflateBlockCompressor() {
+        this(Deflater.BEST_SPEED);
+    }
+
+    public DeflateBlockCompressor(int level) {
+        this.level = level;
+    }
+
+    @Override
+    public byte[] compress(byte[] data) {
+        if (data.length == 0) {
+            return data;
+        }
+        Deflater deflater = new Deflater(level);
+        deflater.setInput(data);
+        deflater.finish();
+        byte[] buffer = new byte[data.length + (data.length >> 1) + 16];
+        int written = deflater.deflate(buffer);
+        deflater.end();
+        byte[] result = new byte[written];
+        System.arraycopy(buffer, 0, result, 0, written);
+        return result;
+    }
+
+    @Override
+    public byte[] decompress(byte[] data, int expectedLength) {
+        if (data.length == 0) {
+            return data;
+        }
+        Inflater inflater = new Inflater();
+        inflater.setInput(data);
+        byte[] result = new byte[expectedLength];
+        try {
+            int written = inflater.inflate(result);
+            if (written != expectedLength) {
+                throw new IllegalStateException("Unexpected decompressed size " + written + " != " + expectedLength);
+            }
+            return result;
+        } catch (DataFormatException e) {
+            throw new IllegalStateException("Failed to inflate chunk field", e);
+        } finally {
+            inflater.end();
+        }
+    }
+}

--- a/src/main/java/baritone/cache/seed/MicroIndex.java
+++ b/src/main/java/baritone/cache/seed/MicroIndex.java
@@ -1,0 +1,24 @@
+package baritone.cache.seed;
+
+/**
+ * Single byte micro-index stored in the region header. It lets the planner skip chunks that
+ * obviously do not contain the data it is searching for without touching the heavier blobs.
+ */
+public enum MicroIndex {
+    HAS_CAVE(1 << 0),
+    HAS_STRUCTURE(1 << 1),
+    HAS_HIGH_ORE(1 << 2),
+    HEIGHT_TRUNCATED(1 << 3),
+    HAS_SURFACE_PORTAL(1 << 4),
+    HAS_PASSABLE_SURFACE(1 << 5);
+
+    private final int bit;
+
+    MicroIndex(int bit) {
+        this.bit = bit;
+    }
+
+    public int bit() {
+        return bit;
+    }
+}

--- a/src/main/java/baritone/cache/seed/PackedHeightField.java
+++ b/src/main/java/baritone/cache/seed/PackedHeightField.java
@@ -1,0 +1,85 @@
+package baritone.cache.seed;
+
+import baritone.utils.io.VarIntUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Stores the column top heights using a base height plus 4-bit signed deltas.
+ */
+public final class PackedHeightField {
+
+    private static final int COLUMN_COUNT = 16 * 16;
+
+    private final int baseY;
+    private final byte[] packed;
+    private final boolean truncated;
+
+    private PackedHeightField(int baseY, byte[] packed, boolean truncated) {
+        this.baseY = baseY;
+        this.packed = packed;
+        this.truncated = truncated;
+    }
+
+    public int topY(int localX, int localZ) {
+        int index = localZ * 16 + localX;
+        int nibble = ((packed[index >> 1] >>> ((index & 1) * 4)) & 0xF);
+        int delta = (nibble & 0x8) != 0 ? nibble - 0x10 : nibble;
+        return baseY + delta;
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+
+    public byte[] toByteArray() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        VarIntUtils.writeZigZag(out, baseY);
+        out.writeBytes(packed);
+        out.write(truncated ? 1 : 0);
+        return out.toByteArray();
+    }
+
+    public static PackedHeightField fromColumns(int[] columns) {
+        if (columns.length != COLUMN_COUNT) {
+            throw new IllegalArgumentException("Expected " + COLUMN_COUNT + " entries");
+        }
+        int min = Integer.MAX_VALUE;
+        int max = Integer.MIN_VALUE;
+        for (int value : columns) {
+            min = Math.min(min, value);
+            max = Math.max(max, value);
+        }
+        int base = (min + max) / 2;
+        byte[] packed = new byte[(COLUMN_COUNT + 1) / 2];
+        boolean truncated = false;
+        for (int i = 0; i < columns.length; i++) {
+            int delta = columns[i] - base;
+            if (delta < -8) {
+                delta = -8;
+                truncated = true;
+            } else if (delta > 7) {
+                delta = 7;
+                truncated = true;
+            }
+            int nibble = delta & 0xF;
+            int byteIndex = i >> 1;
+            if ((i & 1) == 0) {
+                packed[byteIndex] = (byte) (nibble & 0xF);
+            } else {
+                packed[byteIndex] |= (byte) (nibble << 4);
+            }
+        }
+        return new PackedHeightField(base, packed, truncated);
+    }
+
+    public static PackedHeightField decode(byte[] data) {
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        int base = VarIntUtils.readZigZag(buffer);
+        byte[] packed = new byte[(COLUMN_COUNT + 1) / 2];
+        buffer.get(packed);
+        boolean truncated = buffer.hasRemaining() && buffer.get() != 0;
+        return new PackedHeightField(base, packed, truncated);
+    }
+}

--- a/src/main/java/baritone/cache/seed/PassabilityField.java
+++ b/src/main/java/baritone/cache/seed/PassabilityField.java
@@ -1,0 +1,92 @@
+package baritone.cache.seed;
+
+import baritone.utils.io.VarIntUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.util.BitSet;
+
+/**
+ * Compact run-length encoding for 16x16 passability masks.
+ */
+final class PassabilityField {
+
+    private static final int CELL_COUNT = 16 * 16;
+
+    private PassabilityField() {
+    }
+
+    static byte[] pack(BitSet bits) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        boolean current = bits.get(0);
+        int run = 1;
+        for (int i = 1; i < CELL_COUNT; i++) {
+            boolean value = bits.get(i);
+            if (value == current) {
+                run++;
+            } else {
+                writeRun(out, current, run);
+                current = value;
+                run = 1;
+            }
+        }
+        writeRun(out, current, run);
+        return out.toByteArray();
+    }
+
+    static BitSet unpack(byte[] data) {
+        BitSet bits = new BitSet(CELL_COUNT);
+        int index = 0;
+        ByteBufferWrapper wrapper = new ByteBufferWrapper(data);
+        while (wrapper.hasRemaining() && index < CELL_COUNT) {
+            int encoded = wrapper.readUnsigned();
+            boolean value = (encoded & 1) != 0;
+            int run = encoded >>> 1;
+            for (int i = 0; i < run && index < CELL_COUNT; i++, index++) {
+                bits.set(index, value);
+            }
+        }
+        return bits;
+    }
+
+    static boolean hasAnyPassable(byte[] packed) {
+        ByteBufferWrapper wrapper = new ByteBufferWrapper(packed);
+        while (wrapper.hasRemaining()) {
+            int encoded = wrapper.readUnsigned();
+            if ((encoded & 1) != 0 && encoded >>> 1 > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void writeRun(ByteArrayOutputStream out, boolean value, int length) {
+        int encoded = (length << 1) | (value ? 1 : 0);
+        VarIntUtils.writeUnsigned(out, encoded);
+    }
+
+    private static final class ByteBufferWrapper {
+        private final byte[] data;
+        private int index;
+
+        private ByteBufferWrapper(byte[] data) {
+            this.data = data;
+        }
+
+        int readUnsigned() {
+            int value = 0;
+            int shift = 0;
+            while (true) {
+                byte b = data[index++];
+                value |= (b & 0x7F) << shift;
+                if ((b & 0x80) == 0) {
+                    return value;
+                }
+                shift += 7;
+            }
+        }
+
+        boolean hasRemaining() {
+            return index < data.length;
+        }
+    }
+}

--- a/src/main/java/baritone/cache/seed/RegionBlobReader.java
+++ b/src/main/java/baritone/cache/seed/RegionBlobReader.java
@@ -1,6 +1,7 @@
 package baritone.cache.seed;
 
 import java.nio.ByteBuffer;
+import java.util.BitSet;
 import java.util.Objects;
 
 /**
@@ -79,6 +80,15 @@ public final class RegionBlobReader {
         return cache.isPassable(localX, localZ);
     }
 
+    public BitSet passabilityBits(int chunkX, int chunkZ) {
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        if (view == null || !view.hasField(ChunkField.PASSABILITY)) {
+            return null;
+        }
+        byte[] raw = view.readField(ChunkField.PASSABILITY, compressor);
+        return PassabilityField.unpack(raw);
+    }
+
     public boolean hasPassableSurface(int chunkX, int chunkZ) {
         int index = chunkIndex(chunkX, chunkZ);
         if (index < 0) {
@@ -103,6 +113,15 @@ public final class RegionBlobReader {
         byte[] raw = view.readField(ChunkField.HEIGHTS, compressor);
         PackedHeightField field = PackedHeightField.decode(raw);
         return field.topY(localX, localZ);
+    }
+
+    public PackedHeightField heightField(int chunkX, int chunkZ) {
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        if (view == null || !view.hasField(ChunkField.HEIGHTS)) {
+            return null;
+        }
+        byte[] raw = view.readField(ChunkField.HEIGHTS, compressor);
+        return PackedHeightField.decode(raw);
     }
 
     private ChunkSummaryRecordView view(int chunkX, int chunkZ) {

--- a/src/main/java/baritone/cache/seed/RegionBlobReader.java
+++ b/src/main/java/baritone/cache/seed/RegionBlobReader.java
@@ -1,0 +1,148 @@
+package baritone.cache.seed;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Provides random access over a region blob without eager decompression.
+ */
+public final class RegionBlobReader {
+
+    private static final int MAGIC = 0x53435247;
+
+    private final int baseChunkX;
+    private final int baseChunkZ;
+    private final byte[] microIndex;
+    private final int[] offsets;
+    private final int[] lengths;
+    private final ByteBuffer data;
+    private final BlockCompressor compressor;
+    public RegionBlobReader(byte[] blob, BlockCompressor compressor) {
+        this(ByteBuffer.wrap(blob), compressor);
+    }
+
+    public RegionBlobReader(ByteBuffer buffer, BlockCompressor compressor) {
+        Objects.requireNonNull(compressor, "compressor");
+        buffer = buffer.slice();
+        int magic = buffer.getInt();
+        if (magic != MAGIC) {
+            throw new IllegalArgumentException("Not a seed chunk region");
+        }
+        short version = buffer.getShort();
+        if (version != 1) {
+            throw new IllegalArgumentException("Unsupported region version " + version);
+        }
+        this.baseChunkX = buffer.getInt();
+        this.baseChunkZ = buffer.getInt();
+        short chunkSize = buffer.getShort();
+        short regionSize = buffer.getShort();
+        if (chunkSize != RegionLayout.CHUNK_SIZE || regionSize != RegionLayout.REGION_SIZE) {
+            throw new IllegalArgumentException("Unexpected region layout");
+        }
+        int chunkCount = buffer.getInt();
+        if (chunkCount != RegionLayout.CHUNK_COUNT) {
+            throw new IllegalArgumentException("Unexpected chunk count");
+        }
+        int microLength = buffer.getInt();
+        this.microIndex = new byte[microLength];
+        buffer.get(this.microIndex);
+        this.offsets = new int[chunkCount];
+        this.lengths = new int[chunkCount];
+        for (int i = 0; i < chunkCount; i++) {
+            offsets[i] = buffer.getInt();
+            lengths[i] = buffer.getInt();
+        }
+        this.data = buffer.slice();
+        this.compressor = compressor;
+    }
+
+    public ChunkSummaryHeader readHeader(int chunkX, int chunkZ) {
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        return view != null ? view.header() : ChunkSummaryHeader.empty();
+    }
+
+    public boolean hasCave(int chunkX, int chunkZ) {
+        int index = chunkIndex(chunkX, chunkZ);
+        if (index < 0) {
+            return false;
+        }
+        return (microIndex[index] & MicroIndex.HAS_CAVE.bit()) != 0;
+    }
+
+    public boolean isPassable(int chunkX, int chunkZ, int localX, int localZ) {
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        if (view == null || !view.hasField(ChunkField.PASSABILITY)) {
+            return false;
+        }
+        byte[] raw = view.readField(ChunkField.PASSABILITY, compressor);
+        BitSetCache cache = BitSetCache.fromPacked(raw);
+        return cache.isPassable(localX, localZ);
+    }
+
+    public boolean hasPassableSurface(int chunkX, int chunkZ) {
+        int index = chunkIndex(chunkX, chunkZ);
+        if (index < 0) {
+            return false;
+        }
+        if ((microIndex[index] & MicroIndex.HAS_PASSABLE_SURFACE.bit()) != 0) {
+            return true;
+        }
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        if (view == null || !view.hasField(ChunkField.PASSABILITY)) {
+            return false;
+        }
+        byte[] raw = view.readField(ChunkField.PASSABILITY, compressor);
+        return PassabilityField.hasAnyPassable(raw);
+    }
+
+    public int topY(int chunkX, int chunkZ, int localX, int localZ) {
+        ChunkSummaryRecordView view = view(chunkX, chunkZ);
+        if (view == null || !view.hasField(ChunkField.HEIGHTS)) {
+            return 0;
+        }
+        byte[] raw = view.readField(ChunkField.HEIGHTS, compressor);
+        PackedHeightField field = PackedHeightField.decode(raw);
+        return field.topY(localX, localZ);
+    }
+
+    private ChunkSummaryRecordView view(int chunkX, int chunkZ) {
+        int index = chunkIndex(chunkX, chunkZ);
+        if (index < 0) {
+            return null;
+        }
+        int offset = offsets[index];
+        int length = lengths[index];
+        if (offset < 0 || length == 0) {
+            return null;
+        }
+        ByteBuffer slice = data.duplicate();
+        slice.position(offset);
+        slice.limit(offset + length);
+        return new ChunkSummaryRecordView(slice.slice());
+    }
+
+    private int chunkIndex(int chunkX, int chunkZ) {
+        try {
+            return RegionLayout.index(baseChunkX, baseChunkZ, chunkX, chunkZ);
+        } catch (IllegalArgumentException ignored) {
+            return -1;
+        }
+    }
+
+    private static final class BitSetCache {
+        private final java.util.BitSet bitset;
+
+        private BitSetCache(java.util.BitSet bitset) {
+            this.bitset = bitset;
+        }
+
+        static BitSetCache fromPacked(byte[] data) {
+            return new BitSetCache(PassabilityField.unpack(data));
+        }
+
+        boolean isPassable(int localX, int localZ) {
+            int index = localZ * 16 + localX;
+            return bitset.get(index);
+        }
+    }
+}

--- a/src/main/java/baritone/cache/seed/RegionBlobWriter.java
+++ b/src/main/java/baritone/cache/seed/RegionBlobWriter.java
@@ -1,0 +1,67 @@
+package baritone.cache.seed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Serialises region wide chunk summaries into a compact blob.
+ */
+public final class RegionBlobWriter {
+
+    private static final int MAGIC = 0x53435247; // "SCRG"
+    private static final short VERSION = 1;
+
+    private RegionBlobWriter() {
+    }
+
+    public static byte[] write(int baseChunkX, int baseChunkZ, Map<Long, ChunkSummaryRecord> chunks, BlockCompressor compressor) {
+        try {
+            ByteArrayOutputStream chunkOut = new ByteArrayOutputStream();
+            byte[] microIndex = new byte[RegionLayout.CHUNK_COUNT];
+            int[] offsets = new int[RegionLayout.CHUNK_COUNT];
+            int[] lengths = new int[RegionLayout.CHUNK_COUNT];
+            Arrays.fill(offsets, -1);
+            Arrays.fill(lengths, 0);
+
+            for (Map.Entry<Long, ChunkSummaryRecord> entry : chunks.entrySet()) {
+                ChunkSummaryRecord record = entry.getValue();
+                ChunkSummaryPacker.EncodedChunk encoded = ChunkSummaryPacker.encode(record, compressor);
+                int chunkX = (int) (entry.getKey() >> 32);
+                int chunkZ = entry.getKey().intValue();
+                int index = RegionLayout.index(baseChunkX, baseChunkZ, chunkX, chunkZ);
+                offsets[index] = chunkOut.size();
+                lengths[index] = encoded.payload().length;
+                chunkOut.writeBytes(encoded.payload());
+                microIndex[index] = encoded.microIndex();
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            DataOutputStream data = new DataOutputStream(out);
+            data.writeInt(MAGIC);
+            data.writeShort(VERSION);
+            data.writeInt(baseChunkX);
+            data.writeInt(baseChunkZ);
+            data.writeShort(RegionLayout.CHUNK_SIZE);
+            data.writeShort(RegionLayout.REGION_SIZE);
+            data.writeInt(RegionLayout.CHUNK_COUNT);
+            data.writeInt(microIndex.length);
+            data.write(microIndex);
+            for (int i = 0; i < RegionLayout.CHUNK_COUNT; i++) {
+                data.writeInt(offsets[i]);
+                data.writeInt(lengths[i]);
+            }
+            data.write(chunkOut.toByteArray());
+            data.flush();
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to encode region blob", e);
+        }
+    }
+
+    public static long chunkKey(int chunkX, int chunkZ) {
+        return ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
+    }
+}

--- a/src/main/java/baritone/cache/seed/RegionLayout.java
+++ b/src/main/java/baritone/cache/seed/RegionLayout.java
@@ -1,0 +1,23 @@
+package baritone.cache.seed;
+
+/**
+ * Layout constants for the 32x32 chunk region blobs.
+ */
+public final class RegionLayout {
+
+    public static final int CHUNK_SIZE = 16;
+    public static final int REGION_SIZE = 32;
+    public static final int CHUNK_COUNT = REGION_SIZE * REGION_SIZE;
+
+    public static int index(int baseChunkX, int baseChunkZ, int chunkX, int chunkZ) {
+        int dx = chunkX - baseChunkX;
+        int dz = chunkZ - baseChunkZ;
+        if (dx < 0 || dz < 0 || dx >= REGION_SIZE || dz >= REGION_SIZE) {
+            throw new IllegalArgumentException("Chunk outside region");
+        }
+        return dz * REGION_SIZE + dx;
+    }
+
+    private RegionLayout() {
+    }
+}

--- a/src/main/java/baritone/cache/seed/SeedSummaryManager.java
+++ b/src/main/java/baritone/cache/seed/SeedSummaryManager.java
@@ -1,15 +1,20 @@
 package baritone.cache.seed;
 
+import java.util.BitSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Manages predicted chunk summaries keyed by region coordinate.
+ * Manages predicted chunk summaries keyed by region coordinate and exposes aggregated metrics for planning.
  */
 public final class SeedSummaryManager {
 
+    private static final int SEA_LEVEL = 63;
+
     private final BlockCompressor compressor;
     private final Map<Long, RegionBlobReader> regions = new ConcurrentHashMap<>();
+    private final Map<Long, SurfaceMetrics> overrides = new ConcurrentHashMap<>();
+    private final Map<Long, SurfaceMetrics> metricsCache = new ConcurrentHashMap<>();
 
     public SeedSummaryManager(BlockCompressor compressor) {
         this.compressor = compressor;
@@ -18,15 +23,32 @@ public final class SeedSummaryManager {
     public void putRegionBlob(int baseChunkX, int baseChunkZ, byte[] blob) {
         int regionX = Math.floorDiv(baseChunkX, RegionLayout.REGION_SIZE);
         int regionZ = Math.floorDiv(baseChunkZ, RegionLayout.REGION_SIZE);
-        regions.put(regionKey(regionX, regionZ), new RegionBlobReader(blob, compressor));
+        long key = regionKey(regionX, regionZ);
+        regions.put(key, new RegionBlobReader(blob, compressor));
+        invalidateRegion(regionX, regionZ);
+    }
+
+    public void clearAll() {
+        regions.clear();
+        overrides.clear();
+        metricsCache.clear();
     }
 
     public ChunkSummaryHeader readHeader(int chunkX, int chunkZ) {
+        SurfaceMetrics override = overrides.get(chunkKey(chunkX, chunkZ));
+        if (override != null) {
+            // We don't keep full headers for overrides, so fall back to empty header.
+            return ChunkSummaryHeader.empty();
+        }
         RegionBlobReader region = region(chunkX, chunkZ);
         return region != null ? region.readHeader(chunkX, chunkZ) : ChunkSummaryHeader.empty();
     }
 
     public boolean hasCave(int chunkX, int chunkZ) {
+        SurfaceMetrics override = overrides.get(chunkKey(chunkX, chunkZ));
+        if (override != null) {
+            return override.hasCave();
+        }
         RegionBlobReader region = region(chunkX, chunkZ);
         return region != null && region.hasCave(chunkX, chunkZ);
     }
@@ -37,13 +59,89 @@ public final class SeedSummaryManager {
     }
 
     public int topY(int chunkX, int chunkZ, int localX, int localZ) {
+        SurfaceMetrics override = overrides.get(chunkKey(chunkX, chunkZ));
+        if (override != null && override.passableRatio() > 0.0) {
+            return (int) Math.round(override.averageY());
+        }
         RegionBlobReader region = region(chunkX, chunkZ);
         return region != null ? region.topY(chunkX, chunkZ, localX, localZ) : 0;
     }
 
     public boolean hasPassableSurface(int chunkX, int chunkZ) {
+        SurfaceMetrics override = overrides.get(chunkKey(chunkX, chunkZ));
+        if (override != null) {
+            return override.passableRatio() > 0.05;
+        }
         RegionBlobReader region = region(chunkX, chunkZ);
         return region != null && region.hasPassableSurface(chunkX, chunkZ);
+    }
+
+    public SurfaceMetrics metrics(int chunkX, int chunkZ) {
+        long key = chunkKey(chunkX, chunkZ);
+        SurfaceMetrics override = overrides.get(key);
+        if (override != null) {
+            return override;
+        }
+        return metricsCache.computeIfAbsent(key, k -> computeMetrics(chunkX, chunkZ));
+    }
+
+    public void overrideSurfaceMetrics(int chunkX, int chunkZ, SurfaceMetrics metrics) {
+        long key = chunkKey(chunkX, chunkZ);
+        if (metrics == null) {
+            overrides.remove(key);
+            metricsCache.remove(key);
+        } else {
+            overrides.put(key, metrics);
+            metricsCache.put(key, metrics);
+        }
+    }
+
+    private SurfaceMetrics computeMetrics(int chunkX, int chunkZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        if (region == null) {
+            return SurfaceMetrics.EMPTY;
+        }
+        BitSet passability = region.passabilityBits(chunkX, chunkZ);
+        PackedHeightField heights = region.heightField(chunkX, chunkZ);
+        boolean hasCave = region.hasCave(chunkX, chunkZ);
+        if (passability == null && heights == null) {
+            return SurfaceMetrics.EMPTY;
+        }
+        int totalColumns = 16 * 16;
+        double passableRatio = passability != null ? passability.cardinality() / (double) totalColumns : 0.0;
+        if (heights == null) {
+            double waterGuess = passableRatio > 0.8 ? 0.5 : 0.0;
+            double lavaGuess = 0.0;
+            return new SurfaceMetrics(passableRatio, SEA_LEVEL, SEA_LEVEL, SEA_LEVEL, hasCave, false, false, passableRatio < 0.6,
+                    waterGuess, lavaGuess, 0.0);
+        }
+        int min = Integer.MAX_VALUE;
+        int max = Integer.MIN_VALUE;
+        double sum = 0.0;
+        int lowCount = 0;
+        for (int localZ = 0; localZ < 16; localZ++) {
+            for (int localX = 0; localX < 16; localX++) {
+                int y = heights.topY(localX, localZ);
+                min = Math.min(min, y);
+                max = Math.max(max, y);
+                sum += y;
+            }
+        }
+        double average = sum / totalColumns;
+        for (int localZ = 0; localZ < 16; localZ++) {
+            for (int localX = 0; localX < 16; localX++) {
+                int y = heights.topY(localX, localZ);
+                if (y < average - 3) {
+                    lowCount++;
+                }
+            }
+        }
+        boolean likelyHole = lowCount > totalColumns * 0.1 || max - min >= 6;
+        boolean likelyWater = passableRatio > 0.85 && Math.abs(average - SEA_LEVEL) <= 1 && max - min <= 2;
+        boolean likelyLava = average < 20 && passableRatio > 0.4;
+        double waterEstimate = likelyWater ? Math.max(0.4, 1.0 - (1.0 - passableRatio) * 0.5) : 0.0;
+        double lavaEstimate = likelyLava ? Math.min(0.5, (20 - Math.min(average, 20)) / 40.0 + 0.2) : 0.0;
+        return new SurfaceMetrics(passableRatio, min, max, average, hasCave, likelyWater, likelyLava, likelyHole, waterEstimate, lavaEstimate, 0.0);
     }
 
     private RegionBlobReader region(int chunkX, int chunkZ) {
@@ -52,7 +150,21 @@ public final class SeedSummaryManager {
         return regions.get(regionKey(regionX, regionZ));
     }
 
+    private void invalidateRegion(int regionX, int regionZ) {
+        int baseChunkX = regionX * RegionLayout.REGION_SIZE;
+        int baseChunkZ = regionZ * RegionLayout.REGION_SIZE;
+        for (int dz = 0; dz < RegionLayout.REGION_SIZE; dz++) {
+            for (int dx = 0; dx < RegionLayout.REGION_SIZE; dx++) {
+                metricsCache.remove(chunkKey(baseChunkX + dx, baseChunkZ + dz));
+            }
+        }
+    }
+
     private static long regionKey(int regionX, int regionZ) {
         return ((long) regionX << 32) | (regionZ & 0xFFFFFFFFL);
+    }
+
+    private static long chunkKey(int chunkX, int chunkZ) {
+        return ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
     }
 }

--- a/src/main/java/baritone/cache/seed/SeedSummaryManager.java
+++ b/src/main/java/baritone/cache/seed/SeedSummaryManager.java
@@ -1,0 +1,58 @@
+package baritone.cache.seed;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages predicted chunk summaries keyed by region coordinate.
+ */
+public final class SeedSummaryManager {
+
+    private final BlockCompressor compressor;
+    private final Map<Long, RegionBlobReader> regions = new ConcurrentHashMap<>();
+
+    public SeedSummaryManager(BlockCompressor compressor) {
+        this.compressor = compressor;
+    }
+
+    public void putRegionBlob(int baseChunkX, int baseChunkZ, byte[] blob) {
+        int regionX = Math.floorDiv(baseChunkX, RegionLayout.REGION_SIZE);
+        int regionZ = Math.floorDiv(baseChunkZ, RegionLayout.REGION_SIZE);
+        regions.put(regionKey(regionX, regionZ), new RegionBlobReader(blob, compressor));
+    }
+
+    public ChunkSummaryHeader readHeader(int chunkX, int chunkZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        return region != null ? region.readHeader(chunkX, chunkZ) : ChunkSummaryHeader.empty();
+    }
+
+    public boolean hasCave(int chunkX, int chunkZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        return region != null && region.hasCave(chunkX, chunkZ);
+    }
+
+    public boolean isPassable(int chunkX, int chunkZ, int localX, int localZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        return region != null && region.isPassable(chunkX, chunkZ, localX, localZ);
+    }
+
+    public int topY(int chunkX, int chunkZ, int localX, int localZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        return region != null ? region.topY(chunkX, chunkZ, localX, localZ) : 0;
+    }
+
+    public boolean hasPassableSurface(int chunkX, int chunkZ) {
+        RegionBlobReader region = region(chunkX, chunkZ);
+        return region != null && region.hasPassableSurface(chunkX, chunkZ);
+    }
+
+    private RegionBlobReader region(int chunkX, int chunkZ) {
+        int regionX = Math.floorDiv(chunkX, RegionLayout.REGION_SIZE);
+        int regionZ = Math.floorDiv(chunkZ, RegionLayout.REGION_SIZE);
+        return regions.get(regionKey(regionX, regionZ));
+    }
+
+    private static long regionKey(int regionX, int regionZ) {
+        return ((long) regionX << 32) | (regionZ & 0xFFFFFFFFL);
+    }
+}

--- a/src/main/java/baritone/cache/seed/SurfaceMetrics.java
+++ b/src/main/java/baritone/cache/seed/SurfaceMetrics.java
@@ -1,0 +1,126 @@
+package baritone.cache.seed;
+
+import baritone.api.Settings;
+
+/**
+ * Aggregated surface metrics used to influence predictive planning.
+ */
+public record SurfaceMetrics(
+        double passableRatio,
+        int minY,
+        int maxY,
+        double averageY,
+        boolean hasCave,
+        boolean likelyWater,
+        boolean likelyLava,
+        boolean likelyHole,
+        double waterCoverage,
+        double lavaCoverage,
+        double hostileDensity) {
+
+    public static final SurfaceMetrics EMPTY = new SurfaceMetrics(0.0, 0, 0, 0.0, false, false, false, false, 0.0, 0.0, 0.0);
+
+    public boolean isEmpty() {
+        return passableRatio <= 0.0
+                && minY == 0
+                && maxY == 0
+                && !hasCave
+                && !likelyWater
+                && !likelyLava
+                && !likelyHole
+                && waterCoverage <= 0.0
+                && lavaCoverage <= 0.0
+                && hostileDensity <= 0.0;
+    }
+
+    public double traversalCost(Settings settings, boolean preferUnderground) {
+        double passable = clamp01(passableRatio);
+        if (passable <= 0.01) {
+            return preferUnderground && hasCave ? 3.0 : 4.5;
+        }
+
+        double cost = 1.0;
+        cost += (1.0 - passable) * 2.5;
+
+        double effectiveWater = waterCoverage > 0.0 ? clamp01(waterCoverage) : (likelyWater ? 0.6 : 0.0);
+        if (effectiveWater > 0.0) {
+            double basePenalty = settings.assumeWalkOnWater.value ? 0.2 : Math.max(0.6, settings.walkOnWaterOnePenalty.value / 2.5);
+            if (preferUnderground) {
+                basePenalty *= 0.7;
+            }
+            cost += effectiveWater * basePenalty;
+        }
+
+        double effectiveLava = lavaCoverage > 0.0 ? clamp01(lavaCoverage) : (likelyLava ? 0.35 : 0.0);
+        if (effectiveLava > 0.0) {
+            double lavaPenalty = settings.assumeWalkOnLava.value ? 0.8 : 2.5 + effectiveLava * 2.5;
+            if (preferUnderground) {
+                lavaPenalty *= 0.5;
+            }
+            cost += lavaPenalty;
+        }
+
+        if (likelyHole && !preferUnderground) {
+            double holePenalty = settings.allowParkour.value ? 0.45 : 1.0;
+            if (!settings.allowWaterBucketFall.value) {
+                holePenalty += 0.35;
+            }
+            cost += holePenalty;
+        }
+
+        if (hasCave) {
+            cost += preferUnderground ? -0.4 : 0.55;
+        } else if (preferUnderground) {
+            cost += 0.35;
+        }
+
+        int verticalSpan = maxY - minY;
+        if (verticalSpan >= 12) {
+            double spanPenalty = settings.allowWaterBucketFall.value ? 0.25 : 0.7;
+            if (preferUnderground) {
+                spanPenalty *= 0.7;
+            }
+            cost += spanPenalty;
+        }
+
+        if (hostileDensity > 0.0) {
+            double mobPenalty = Math.min(3.25, hostileDensity * 2.6);
+            if (settings.allowParkour.value) {
+                mobPenalty *= 0.9;
+            }
+            if (settings.allowVines.value) {
+                mobPenalty *= 0.95;
+            }
+            cost += mobPenalty;
+        }
+
+        if (!preferUnderground && effectiveWater < 0.1 && passable > 0.65 && settings.allowSprint.value) {
+            cost -= 0.15;
+        }
+
+        return clamp(cost, 0.25, 5.0);
+    }
+
+    public boolean isViable(Settings settings, boolean preferUnderground) {
+        double passable = clamp01(passableRatio);
+        if (passable <= 0.01) {
+            return false;
+        }
+        double effectiveLava = lavaCoverage > 0.0 ? clamp01(lavaCoverage) : (likelyLava ? 0.35 : 0.0);
+        if (!preferUnderground && effectiveLava > 0.2 && !settings.assumeWalkOnLava.value) {
+            return false;
+        }
+        if (!preferUnderground && hostileDensity > 3.5) {
+            return false;
+        }
+        return true;
+    }
+
+    private static double clamp01(double value) {
+        return clamp(value, 0.0, 1.0);
+    }
+
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+}

--- a/src/main/java/baritone/cache/seed/VerticalBandField.java
+++ b/src/main/java/baritone/cache/seed/VerticalBandField.java
@@ -1,0 +1,73 @@
+package baritone.cache.seed;
+
+import baritone.utils.io.VarIntUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Stores 8-bit band occupancy per column for subsurface summaries (caves, ores).
+ */
+public final class VerticalBandField {
+
+    private static final int COLUMN_COUNT = 16 * 16;
+
+    private final byte bandsPerColumn;
+    private final byte[] values;
+
+    private VerticalBandField(byte bandsPerColumn, byte[] values) {
+        this.bandsPerColumn = bandsPerColumn;
+        this.values = values;
+    }
+
+    public byte bandsPerColumn() {
+        return bandsPerColumn;
+    }
+
+    public byte[] toByteArray() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(bandsPerColumn);
+        VarIntUtils.writeUnsigned(out, values.length);
+        out.writeBytes(values);
+        return out.toByteArray();
+    }
+
+    public byte bandValue(int localX, int localZ, int band) {
+        int index = ((localZ * 16) + localX) * bandsPerColumn + band;
+        return values[index];
+    }
+
+    public boolean hasAny() {
+        for (byte value : values) {
+            if (value != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static VerticalBandField decode(byte[] data) {
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        byte bands = buffer.get();
+        int length = VarIntUtils.readUnsigned(buffer);
+        byte[] values = new byte[length];
+        buffer.get(values);
+        return new VerticalBandField(bands, values);
+    }
+
+    public static byte[] encode(byte bandsPerColumn, byte[] values) {
+        return new VerticalBandField(bandsPerColumn, values).toByteArray();
+    }
+
+    static boolean hasAnyEncoded(byte[] encoded) {
+        ByteBuffer buffer = ByteBuffer.wrap(encoded);
+        buffer.get();
+        int length = VarIntUtils.readUnsigned(buffer);
+        for (int i = 0; i < length; i++) {
+            if (buffer.get() != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -32,6 +32,8 @@ public final class DefaultCommands {
         List<ICommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(baritone),
                 new SetCommand(baritone),
+                new SeedCommand(baritone),
+                new SeedPredictionCommand(baritone),
                 new CommandAlias(baritone, Arrays.asList("modified", "mod", "baritone", "modifiedsettings"), "List modified settings", "set modified"),
                 new CommandAlias(baritone, "reset", "Reset all settings or just one", "set reset"),
                 new GoalCommand(baritone),

--- a/src/main/java/baritone/command/defaults/SeedCommand.java
+++ b/src/main/java/baritone/command/defaults/SeedCommand.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+import baritone.api.command.exception.CommandInvalidTypeException;
+import baritone.api.pathing.seed.ISeedPathing;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalLong;
+import java.util.stream.Stream;
+
+public final class SeedCommand extends Command {
+
+    public SeedCommand(IBaritone baritone) {
+        super(baritone, "seed");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        ISeedPathing seedPathing = baritone.getSeedPathing();
+        if (!args.hasAny()) {
+            OptionalLong value = seedPathing.seed();
+            if (value.isPresent()) {
+                logDirect("Configured predictive seed: " + value.getAsLong());
+            } else {
+                logDirect("No predictive seed configured.");
+            }
+            return;
+        }
+        String action = args.getString().toLowerCase(Locale.US);
+        switch (action) {
+            case "set" -> {
+                args.requireMin(1);
+                String seedLiteral = args.getString();
+                long seed;
+                try {
+                    seed = Long.parseLong(seedLiteral);
+                } catch (NumberFormatException ex) {
+                    throw new CommandInvalidTypeException(args.consumed(), "a valid long seed", seedLiteral);
+                }
+                args.requireMax(0);
+                seedPathing.setSeed(seed);
+                logDirect("Predictive planning seed set to " + seed + ".");
+            }
+            case "clear" -> {
+                args.requireMax(0);
+                seedPathing.clearSeed();
+                logDirect("Cleared predictive planning seed.");
+            }
+            default -> throw new CommandInvalidTypeException(args.consumed(), "a valid seed action", action);
+        }
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Configure the predictive planning seed.";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "Sets or clears the seed used by seed-based predictive planning.",
+                "",
+                "Usage:",
+                "> seed - show the currently configured seed",
+                "> seed set <seed> - configure the world seed for predictive planning",
+                "> seed clear - remove the configured predictive seed"
+        );
+    }
+}

--- a/src/main/java/baritone/command/defaults/SeedPredictionCommand.java
+++ b/src/main/java/baritone/command/defaults/SeedPredictionCommand.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+import baritone.api.command.exception.CommandInvalidTypeException;
+import baritone.api.pathing.seed.ISeedPathing;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+public final class SeedPredictionCommand extends Command {
+
+    public SeedPredictionCommand(IBaritone baritone) {
+        super(baritone, "seedbasedprediction");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        ISeedPathing seedPathing = baritone.getSeedPathing();
+        if (!args.hasAny()) {
+            logDirect("Seed-based prediction is " + (seedPathing.isPredictionEnabled() ? "enabled" : "disabled") + ".");
+            if (!seedPathing.hasSeed()) {
+                logDirect("No predictive seed is configured. Use #seed set <seed> first.");
+            }
+            return;
+        }
+        String desired = args.getString().toLowerCase(Locale.US);
+        boolean enable;
+        if (desired.equals("true") || desired.equals("on") || desired.equals("enable")) {
+            enable = true;
+        } else if (desired.equals("false") || desired.equals("off") || desired.equals("disable")) {
+            enable = false;
+        } else {
+            throw new CommandInvalidTypeException(args.consumed(), "true/false", desired);
+        }
+        args.requireMax(0);
+        if (enable) {
+            if (!seedPathing.setPredictionEnabled(true)) {
+                logDirect("Cannot enable seed-based prediction without a configured seed. Use #seed set <seed> first.");
+                return;
+            }
+            logDirect("Seed-based predictive planning enabled.");
+        } else {
+            seedPathing.setPredictionEnabled(false);
+            logDirect("Seed-based predictive planning disabled.");
+        }
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Toggle seed-based predictive planning.";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "Controls whether predictive planning uses the configured seed.",
+                "",
+                "Usage:",
+                "> seedbasedprediction - show current status",
+                "> seedbasedprediction true|on - enable predictive planning (requires a configured seed)",
+                "> seedbasedprediction false|off - disable predictive planning"
+        );
+    }
+}

--- a/src/main/java/baritone/pathing/seed/PredictivePathPlanner.java
+++ b/src/main/java/baritone/pathing/seed/PredictivePathPlanner.java
@@ -1,8 +1,10 @@
 package baritone.pathing.seed;
 
+import baritone.api.Settings;
 import baritone.api.utils.BetterBlockPos;
 import baritone.cache.seed.RegionLayout;
 import baritone.cache.seed.SeedSummaryManager;
+import baritone.cache.seed.SurfaceMetrics;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,14 +23,16 @@ import java.util.Set;
 public final class PredictivePathPlanner {
 
     private final SeedSummaryManager summaries;
+    private final Settings settings;
 
-    public PredictivePathPlanner(SeedSummaryManager summaries) {
+    public PredictivePathPlanner(SeedSummaryManager summaries, Settings settings) {
         this.summaries = Objects.requireNonNull(summaries);
+        this.settings = Objects.requireNonNull(settings);
     }
 
     public PlannerResult plan(BetterBlockPos start, BetterBlockPos goal, PredictivePlannerOptions options) {
         options = options != null ? options : PredictivePlannerOptions.defaults();
-        MacroGraph graph = new MacroGraph(summaries, options.macroTileSize());
+        MacroGraph graph = new MacroGraph(summaries, settings, options.macroTileSize(), options.preferUnderground());
         MacroNode startNode = graph.nodeFor(start);
         MacroNode goalNode = graph.nodeFor(goal);
         if (!graph.isPassable(goalNode)) {
@@ -95,11 +99,15 @@ public final class PredictivePathPlanner {
 
     private static final class MacroGraph {
         private final SeedSummaryManager summaries;
+        private final Settings settings;
         private final int macroTileSize;
+        private final boolean preferUnderground;
 
-        private MacroGraph(SeedSummaryManager summaries, int macroTileSize) {
+        private MacroGraph(SeedSummaryManager summaries, Settings settings, int macroTileSize, boolean preferUnderground) {
             this.summaries = summaries;
+            this.settings = settings;
             this.macroTileSize = Math.max(1, macroTileSize);
+            this.preferUnderground = preferUnderground;
         }
 
         MacroNode nodeFor(BetterBlockPos pos) {
@@ -111,16 +119,21 @@ public final class PredictivePathPlanner {
         }
 
         boolean isPassable(MacroNode node) {
+            boolean sawData = false;
             for (int dz = 0; dz < macroTileSize; dz++) {
                 for (int dx = 0; dx < macroTileSize; dx++) {
                     int chunkX = node.tileX * macroTileSize + dx;
                     int chunkZ = node.tileZ * macroTileSize + dz;
-                    if (summaries.hasPassableSurface(chunkX, chunkZ)) {
-                        return true;
+                    SurfaceMetrics metrics = summaries.metrics(chunkX, chunkZ);
+                    if (metrics != SurfaceMetrics.EMPTY) {
+                        sawData = true;
+                        if (metrics.isViable(settings, preferUnderground)) {
+                            return true;
+                        }
                     }
                 }
             }
-            return false;
+            return !sawData;
         }
 
         Iterable<MacroNode> neighbors(MacroNode node) {
@@ -133,7 +146,22 @@ public final class PredictivePathPlanner {
         }
 
         double cost(MacroNode a, MacroNode b) {
-            return a.tileX == b.tileX || a.tileZ == b.tileZ ? 1 : Math.sqrt(2);
+            double distance = (a.tileX == b.tileX || a.tileZ == b.tileZ) ? 1.0 : Math.sqrt(2);
+            double aggregate = 0.0;
+            int samples = 0;
+            for (int dz = 0; dz < macroTileSize; dz++) {
+                for (int dx = 0; dx < macroTileSize; dx++) {
+                    int chunkX = b.tileX * macroTileSize + dx;
+                    int chunkZ = b.tileZ * macroTileSize + dz;
+                    SurfaceMetrics metrics = summaries.metrics(chunkX, chunkZ);
+                    if (metrics != SurfaceMetrics.EMPTY) {
+                        aggregate += metrics.traversalCost(settings, preferUnderground);
+                        samples++;
+                    }
+                }
+            }
+            double bias = samples > 0 ? aggregate / samples : 1.0;
+            return distance * bias;
         }
 
         BetterBlockPos tileCenter(MacroNode node) {
@@ -141,7 +169,13 @@ public final class PredictivePathPlanner {
             int chunkZ = node.tileZ * macroTileSize + macroTileSize / 2;
             int blockX = chunkX * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
             int blockZ = chunkZ * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
-            int surface = summaries.topY(chunkX, chunkZ, RegionLayout.CHUNK_SIZE / 2, RegionLayout.CHUNK_SIZE / 2);
+            SurfaceMetrics metrics = summaries.metrics(chunkX, chunkZ);
+            int surface;
+            if (metrics != SurfaceMetrics.EMPTY && metrics.passableRatio() > 0.0) {
+                surface = (int) Math.round(metrics.averageY());
+            } else {
+                surface = summaries.topY(chunkX, chunkZ, RegionLayout.CHUNK_SIZE / 2, RegionLayout.CHUNK_SIZE / 2);
+            }
             return new BetterBlockPos(blockX, surface, blockZ);
         }
     }

--- a/src/main/java/baritone/pathing/seed/PredictivePathPlanner.java
+++ b/src/main/java/baritone/pathing/seed/PredictivePathPlanner.java
@@ -1,0 +1,161 @@
+package baritone.pathing.seed;
+
+import baritone.api.utils.BetterBlockPos;
+import baritone.cache.seed.RegionLayout;
+import baritone.cache.seed.SeedSummaryManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * CPU-first macro planner that reasons about compressed seed summaries. It runs a weighted A*
+ * search across macro tiles and defers expensive chunk decoding until a tile is expanded.
+ */
+public final class PredictivePathPlanner {
+
+    private final SeedSummaryManager summaries;
+
+    public PredictivePathPlanner(SeedSummaryManager summaries) {
+        this.summaries = Objects.requireNonNull(summaries);
+    }
+
+    public PlannerResult plan(BetterBlockPos start, BetterBlockPos goal, PredictivePlannerOptions options) {
+        options = options != null ? options : PredictivePlannerOptions.defaults();
+        MacroGraph graph = new MacroGraph(summaries, options.macroTileSize());
+        MacroNode startNode = graph.nodeFor(start);
+        MacroNode goalNode = graph.nodeFor(goal);
+        if (!graph.isPassable(goalNode)) {
+            return PlannerResult.failed();
+        }
+
+        Queue<SearchNode> open = new PriorityQueue<>((a, b) -> Double.compare(a.fScore, b.fScore));
+        Map<MacroNode, Double> gScores = new HashMap<>();
+        Set<MacroNode> closed = new HashSet<>();
+
+        SearchNode startSearch = new SearchNode(startNode, null, 0, heuristic(startNode, goalNode, options.heuristicWeight()));
+        open.add(startSearch);
+        gScores.put(startNode, 0.0);
+
+        int iterations = 0;
+        while (!open.isEmpty() && iterations++ < options.maxIterations()) {
+            SearchNode current = open.poll();
+            if (current.node.equals(goalNode)) {
+                return PlannerResult.success(reconstruct(current, graph, goal));
+            }
+            if (!closed.add(current.node)) {
+                continue;
+            }
+            for (MacroNode neighbor : graph.neighbors(current.node)) {
+                if (!graph.isPassable(neighbor) || closed.contains(neighbor)) {
+                    continue;
+                }
+                double tentativeG = current.gScore + graph.cost(current.node, neighbor);
+                double existing = gScores.getOrDefault(neighbor, Double.POSITIVE_INFINITY);
+                if (tentativeG >= existing) {
+                    continue;
+                }
+                gScores.put(neighbor, tentativeG);
+                double h = heuristic(neighbor, goalNode, options.heuristicWeight());
+                open.add(new SearchNode(neighbor, current, tentativeG, tentativeG + h));
+            }
+        }
+        return PlannerResult.failed();
+    }
+
+    private static double heuristic(MacroNode node, MacroNode goal, double weight) {
+        double dx = Math.abs(node.tileX - goal.tileX);
+        double dz = Math.abs(node.tileZ - goal.tileZ);
+        return weight * (dx + dz);
+    }
+
+    private static List<BetterBlockPos> reconstruct(SearchNode node, MacroGraph graph, BetterBlockPos goal) {
+        List<BetterBlockPos> result = new ArrayList<>();
+        SearchNode cursor = node;
+        while (cursor != null) {
+            result.add(graph.tileCenter(cursor.node));
+            cursor = cursor.parent;
+        }
+        result.set(0, goal);
+        List<BetterBlockPos> reversed = new ArrayList<>(result.size());
+        for (int i = result.size() - 1; i >= 0; i--) {
+            reversed.add(result.get(i));
+        }
+        return reversed;
+    }
+
+    private record SearchNode(MacroNode node, SearchNode parent, double gScore, double fScore) {
+    }
+
+    private static final class MacroGraph {
+        private final SeedSummaryManager summaries;
+        private final int macroTileSize;
+
+        private MacroGraph(SeedSummaryManager summaries, int macroTileSize) {
+            this.summaries = summaries;
+            this.macroTileSize = Math.max(1, macroTileSize);
+        }
+
+        MacroNode nodeFor(BetterBlockPos pos) {
+            int chunkX = Math.floorDiv(pos.getX(), RegionLayout.CHUNK_SIZE);
+            int chunkZ = Math.floorDiv(pos.getZ(), RegionLayout.CHUNK_SIZE);
+            int tileX = Math.floorDiv(chunkX, macroTileSize);
+            int tileZ = Math.floorDiv(chunkZ, macroTileSize);
+            return new MacroNode(tileX, tileZ);
+        }
+
+        boolean isPassable(MacroNode node) {
+            for (int dz = 0; dz < macroTileSize; dz++) {
+                for (int dx = 0; dx < macroTileSize; dx++) {
+                    int chunkX = node.tileX * macroTileSize + dx;
+                    int chunkZ = node.tileZ * macroTileSize + dz;
+                    if (summaries.hasPassableSurface(chunkX, chunkZ)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        Iterable<MacroNode> neighbors(MacroNode node) {
+            List<MacroNode> out = new ArrayList<>(4);
+            out.add(new MacroNode(node.tileX + 1, node.tileZ));
+            out.add(new MacroNode(node.tileX - 1, node.tileZ));
+            out.add(new MacroNode(node.tileX, node.tileZ + 1));
+            out.add(new MacroNode(node.tileX, node.tileZ - 1));
+            return out;
+        }
+
+        double cost(MacroNode a, MacroNode b) {
+            return a.tileX == b.tileX || a.tileZ == b.tileZ ? 1 : Math.sqrt(2);
+        }
+
+        BetterBlockPos tileCenter(MacroNode node) {
+            int chunkX = node.tileX * macroTileSize + macroTileSize / 2;
+            int chunkZ = node.tileZ * macroTileSize + macroTileSize / 2;
+            int blockX = chunkX * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
+            int blockZ = chunkZ * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
+            int surface = summaries.topY(chunkX, chunkZ, RegionLayout.CHUNK_SIZE / 2, RegionLayout.CHUNK_SIZE / 2);
+            return new BetterBlockPos(blockX, surface, blockZ);
+        }
+    }
+
+    private record MacroNode(int tileX, int tileZ) {
+    }
+
+    public record PlannerResult(boolean success, List<BetterBlockPos> waypoints) {
+        public static PlannerResult success(List<BetterBlockPos> waypoints) {
+            return new PlannerResult(true, waypoints);
+        }
+
+        public static PlannerResult failed() {
+            return new PlannerResult(false, List.of());
+        }
+    }
+}

--- a/src/main/java/baritone/pathing/seed/PredictivePlannerOptions.java
+++ b/src/main/java/baritone/pathing/seed/PredictivePlannerOptions.java
@@ -1,0 +1,14 @@
+package baritone.pathing.seed;
+
+/**
+ * Configuration values for the predictive planner.
+ */
+public record PredictivePlannerOptions(
+        int macroTileSize,
+        double heuristicWeight,
+        int maxIterations) {
+
+    public static PredictivePlannerOptions defaults() {
+        return new PredictivePlannerOptions(4, 1.5, 25000);
+    }
+}

--- a/src/main/java/baritone/pathing/seed/PredictivePlannerOptions.java
+++ b/src/main/java/baritone/pathing/seed/PredictivePlannerOptions.java
@@ -6,9 +6,17 @@ package baritone.pathing.seed;
 public record PredictivePlannerOptions(
         int macroTileSize,
         double heuristicWeight,
-        int maxIterations) {
+        int maxIterations,
+        boolean preferUnderground) {
 
     public static PredictivePlannerOptions defaults() {
-        return new PredictivePlannerOptions(4, 1.5, 25000);
+        return new PredictivePlannerOptions(4, 1.5, 25000, false);
+    }
+
+    public PredictivePlannerOptions withPreferUnderground(boolean preferUnderground) {
+        if (this.preferUnderground == preferUnderground) {
+            return this;
+        }
+        return new PredictivePlannerOptions(macroTileSize, heuristicWeight, maxIterations, preferUnderground);
     }
 }

--- a/src/main/java/baritone/pathing/seed/SeedPredictionService.java
+++ b/src/main/java/baritone/pathing/seed/SeedPredictionService.java
@@ -1,0 +1,349 @@
+package baritone.pathing.seed;
+
+import baritone.Baritone;
+import baritone.api.Settings;
+import baritone.api.pathing.calc.IPath;
+import baritone.api.pathing.goals.Goal;
+import baritone.api.pathing.goals.GoalXZ;
+import baritone.api.pathing.goals.GoalYLevel;
+import baritone.api.pathing.seed.ISeedPathing;
+import baritone.api.utils.BetterBlockPos;
+import baritone.api.utils.interfaces.IGoalRenderPos;
+import baritone.api.event.events.ChunkEvent;
+import baritone.api.event.events.type.EventState;
+import baritone.api.event.listener.AbstractGameEventListener;
+import baritone.cache.seed.DeflateBlockCompressor;
+import baritone.cache.seed.RegionLayout;
+import baritone.cache.seed.SeedSummaryManager;
+import baritone.cache.seed.SurfaceMetrics;
+import baritone.pathing.movement.CalculationContext;
+import baritone.utils.BlockStateInterface;
+import baritone.utils.pathing.Favoring;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.AABB;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static baritone.pathing.movement.MovementHelper.canWalkOn;
+import static baritone.pathing.movement.MovementHelper.canWalkThrough;
+
+/**
+ * Coordinates seed-based predictive planning and observed chunk overrides.
+ */
+public final class SeedPredictionService implements ISeedPathing, AbstractGameEventListener {
+
+    private final Baritone baritone;
+    private final SeedSummaryManager summaries;
+    private final PredictivePathPlanner planner;
+    private final AtomicReference<PlannerCache> cache = new AtomicReference<>();
+
+    private volatile boolean enabled;
+    private volatile Long configuredSeed;
+
+    public SeedPredictionService(Baritone baritone) {
+        this.baritone = baritone;
+        this.summaries = new SeedSummaryManager(new DeflateBlockCompressor());
+        Settings settings = Baritone.settings();
+        this.planner = new PredictivePathPlanner(summaries, settings);
+        if (settings.seedPredictionSeedConfigured.value) {
+            this.configuredSeed = settings.seedPredictionSeed.value;
+        }
+        this.enabled = settings.seedBasedPrediction.value && configuredSeed != null;
+    }
+
+    @Override
+    public OptionalLong seed() {
+        Long value = configuredSeed;
+        return value != null ? OptionalLong.of(value) : OptionalLong.empty();
+    }
+
+    @Override
+    public boolean hasSeed() {
+        return configuredSeed != null;
+    }
+
+    @Override
+    public void setSeed(long seed) {
+        this.configuredSeed = seed;
+        Settings settings = Baritone.settings();
+        settings.seedPredictionSeed.value = seed;
+        settings.seedPredictionSeedConfigured.value = true;
+        summaries.clearAll();
+        cache.set(null);
+        if (settings.seedBasedPrediction.value) {
+            this.enabled = true;
+        }
+    }
+
+    @Override
+    public void clearSeed() {
+        configuredSeed = null;
+        Settings settings = Baritone.settings();
+        settings.seedPredictionSeedConfigured.value = false;
+        summaries.clearAll();
+        cache.set(null);
+        enabled = false;
+        settings.seedBasedPrediction.value = false;
+    }
+
+    @Override
+    public boolean isPredictionEnabled() {
+        return enabled && configuredSeed != null;
+    }
+
+    @Override
+    public boolean setPredictionEnabled(boolean enabled) {
+        if (enabled && configuredSeed == null) {
+            this.enabled = false;
+            Baritone.settings().seedBasedPrediction.value = false;
+            return false;
+        }
+        this.enabled = enabled;
+        Baritone.settings().seedBasedPrediction.value = enabled;
+        if (!enabled) {
+            cache.set(null);
+        }
+        return isPredictionEnabled();
+    }
+
+    public void applySeedFavoring(BetterBlockPos start, Goal goal, Favoring favoring, CalculationContext context, IPath previous) {
+        if (!isPredictionEnabled()) {
+            return;
+        }
+        BetterBlockPos goalPos = resolveGoal(goal, start);
+        if (goalPos == null) {
+            return;
+        }
+        boolean preferUnderground = shouldPreferUnderground(start, goalPos);
+        List<BetterBlockPos> waypoints = planMacroPath(start, goalPos, preferUnderground);
+        if (waypoints.isEmpty()) {
+            return;
+        }
+        for (int i = 1; i < waypoints.size(); i++) {
+            BetterBlockPos waypoint = waypoints.get(i);
+            favoring.multiply(BetterBlockPos.longHash(waypoint), 0.9);
+        }
+        biasChunksAlongPath(favoring, waypoints, preferUnderground);
+    }
+
+    @Override
+    public void onChunkEvent(ChunkEvent event) {
+        if (event.getState() != EventState.POST) {
+            return;
+        }
+        if (event.getType() == ChunkEvent.Type.UNLOAD) {
+            summaries.overrideSurfaceMetrics(event.getX(), event.getZ(), null);
+            return;
+        }
+        if (event.getType() == ChunkEvent.Type.LOAD || event.getType().isPopulate()) {
+            Level world = baritone.getPlayerContext().world();
+            if (world == null) {
+                return;
+            }
+            LevelChunk chunk = world.getChunk(event.getX(), event.getZ());
+            SurfaceMetrics metrics = analyzeChunk(world, chunk);
+            if (metrics != null) {
+                summaries.overrideSurfaceMetrics(event.getX(), event.getZ(), metrics);
+            }
+        }
+    }
+
+    private List<BetterBlockPos> planMacroPath(BetterBlockPos start, BetterBlockPos goal, boolean preferUnderground) {
+        PlannerCache cached = cache.get();
+        if (cached != null && cached.matches(start, goal, preferUnderground)) {
+            return cached.waypoints();
+        }
+        PredictivePlannerOptions options = PredictivePlannerOptions.defaults().withPreferUnderground(preferUnderground);
+        PredictivePathPlanner.PlannerResult result = planner.plan(start, goal, options);
+        if (!result.success()) {
+            cache.set(null);
+            return Collections.emptyList();
+        }
+        List<BetterBlockPos> waypoints = new ArrayList<>(result.waypoints());
+        cache.set(new PlannerCache(start, goal, preferUnderground, waypoints));
+        return waypoints;
+    }
+
+    private BetterBlockPos resolveGoal(Goal goal, BetterBlockPos startFallback) {
+        if (goal instanceof IGoalRenderPos renderable) {
+            return new BetterBlockPos(renderable.getGoalPos());
+        }
+        if (goal instanceof GoalXZ goalXZ) {
+            return new BetterBlockPos(goalXZ.getX(), startFallback.getY(), goalXZ.getZ());
+        }
+        if (goal instanceof GoalYLevel yLevel) {
+            return new BetterBlockPos(startFallback.getX(), yLevel.level, startFallback.getZ());
+        }
+        return null;
+    }
+
+    private boolean shouldPreferUnderground(BetterBlockPos start, BetterBlockPos goal) {
+        SurfaceMetrics startMetrics = summaries.metrics(start.getX() >> 4, start.getZ() >> 4);
+        SurfaceMetrics goalMetrics = summaries.metrics(goal.getX() >> 4, goal.getZ() >> 4);
+        boolean startUnderground = startMetrics != SurfaceMetrics.EMPTY && start.getY() < startMetrics.averageY() - 3;
+        boolean goalUnderground = goalMetrics != SurfaceMetrics.EMPTY && goal.getY() < goalMetrics.averageY() - 3;
+        return startUnderground || goalUnderground;
+    }
+
+    private void biasChunksAlongPath(Favoring favoring, List<BetterBlockPos> waypoints, boolean preferUnderground) {
+        Settings settings = Baritone.settings();
+        LongOpenHashSet visited = new LongOpenHashSet();
+        for (int i = 1; i < waypoints.size(); i++) {
+            BetterBlockPos from = waypoints.get(i - 1);
+            BetterBlockPos to = waypoints.get(i);
+            walkChunks(from, to, visited, (chunkX, chunkZ) -> {
+                SurfaceMetrics metrics = summaries.metrics(chunkX, chunkZ);
+                if (metrics == SurfaceMetrics.EMPTY) {
+                    return;
+                }
+                double multiplier = metrics.traversalCost(settings, preferUnderground);
+                multiplier = Math.max(0.35, Math.min(multiplier, 4.0));
+                int blockX = chunkX * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
+                int blockZ = chunkZ * RegionLayout.CHUNK_SIZE + RegionLayout.CHUNK_SIZE / 2;
+                int y = (int) Math.round(metrics.averageY());
+                favoring.multiply(BetterBlockPos.longHash(blockX, y, blockZ), multiplier);
+            });
+        }
+    }
+
+    private SurfaceMetrics analyzeChunk(Level world, LevelChunk chunk) {
+        if (chunk == null || chunk.isEmpty()) {
+            return null;
+        }
+        BlockStateInterface bsi = new BlockStateInterface(baritone.getPlayerContext());
+        int total = 0;
+        int passable = 0;
+        int water = 0;
+        int lava = 0;
+        int cave = 0;
+        int minY = Integer.MAX_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        double sumY = 0.0;
+        int minBuildHeight = world.dimensionType().minY();
+        for (int localX = 0; localX < 16; localX++) {
+            for (int localZ = 0; localZ < 16; localZ++) {
+                int topY = chunk.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, localX, localZ);
+                if (topY <= minBuildHeight) {
+                    continue;
+                }
+                int worldX = chunk.getPos().getMinBlockX() + localX;
+                int worldZ = chunk.getPos().getMinBlockZ() + localZ;
+                BlockPos surfacePos = new BlockPos(worldX, topY - 1, worldZ);
+                BlockState surface = chunk.getBlockState(surfacePos);
+                BlockState head = chunk.getBlockState(surfacePos.above());
+                boolean canStand = canWalkOn(bsi, worldX, surfacePos.getY(), worldZ, surface)
+                        && canWalkThrough(bsi, worldX, surfacePos.getY() + 1, worldZ, head);
+                if (canStand) {
+                    passable++;
+                }
+                total++;
+                int y = surfacePos.getY();
+                minY = Math.min(minY, y);
+                maxY = Math.max(maxY, y);
+                sumY += y;
+                FluidState surfaceFluid = surface.getFluidState();
+                if (!surfaceFluid.isEmpty()) {
+                    if (surfaceFluid.is(FluidTags.WATER)) {
+                        water++;
+                    } else if (surfaceFluid.is(FluidTags.LAVA)) {
+                        lava++;
+                    }
+                }
+                FluidState headFluid = head.getFluidState();
+                if (!headFluid.isEmpty()) {
+                    if (headFluid.is(FluidTags.WATER)) {
+                        water++;
+                    } else if (headFluid.is(FluidTags.LAVA)) {
+                        lava++;
+                    }
+                }
+                int floor = chunk.getHeight(Heightmap.Types.OCEAN_FLOOR, localX, localZ);
+                if (y - floor > 4) {
+                    cave++;
+                }
+            }
+        }
+        if (total == 0) {
+            return null;
+        }
+        ChunkPos pos = chunk.getPos();
+        double minX = pos.getMinBlockX();
+        double minZ = pos.getMinBlockZ();
+        double maxX = pos.getMaxBlockX() + 1;
+        double maxZ = pos.getMaxBlockZ() + 1;
+        double minBoxY = minBuildHeight;
+        double maxBoxY = minBuildHeight + world.dimensionType().height();
+        List<Mob> hostiles = world.getEntitiesOfClass(Mob.class,
+                new AABB(minX, minBoxY, minZ, maxX, maxBoxY, maxZ),
+                mob -> mob.isAlive() && mob.getType().getCategory() == MobCategory.MONSTER);
+        double hostileDensity = hostiles.size() / 5.0;
+        double ratio = passable / (double) total;
+        double average = sumY / total;
+        boolean likelyHole = maxY - minY >= 6;
+        boolean likelyWater = water > total * 0.2;
+        boolean likelyLava = lava > 0;
+        boolean hasCave = cave > total * 0.15;
+        double waterRatio = water / (double) total;
+        double lavaRatio = lava / (double) total;
+        return new SurfaceMetrics(ratio, minY, maxY, average, hasCave, likelyWater, likelyLava, likelyHole, waterRatio, lavaRatio, hostileDensity);
+    }
+
+    private void walkChunks(BetterBlockPos from, BetterBlockPos to, LongOpenHashSet visited, ChunkVisitor visitor) {
+        int x0 = from.getX() >> 4;
+        int z0 = from.getZ() >> 4;
+        int x1 = to.getX() >> 4;
+        int z1 = to.getZ() >> 4;
+        int dx = Math.abs(x1 - x0);
+        int dz = Math.abs(z1 - z0);
+        int sx = x0 < x1 ? 1 : -1;
+        int sz = z0 < z1 ? 1 : -1;
+        int err = dx - dz;
+        int cx = x0;
+        int cz = z0;
+        while (true) {
+            long key = (((long) cx) << 32) | (cz & 0xFFFFFFFFL);
+            if (visited.add(key)) {
+                visitor.visit(cx, cz);
+            }
+            if (cx == x1 && cz == z1) {
+                break;
+            }
+            int e2 = err << 1;
+            if (e2 > -dz) {
+                err -= dz;
+                cx += sx;
+            }
+            if (e2 < dx) {
+                err += dx;
+                cz += sz;
+            }
+        }
+    }
+
+    private record PlannerCache(BetterBlockPos start, BetterBlockPos goal, boolean preferUnderground, List<BetterBlockPos> waypoints) {
+        boolean matches(BetterBlockPos newStart, BetterBlockPos newGoal, boolean preferUnderground) {
+            return this.preferUnderground == preferUnderground
+                    && start.equals(newStart)
+                    && goal.equals(newGoal);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ChunkVisitor {
+        void visit(int chunkX, int chunkZ);
+    }
+}

--- a/src/main/java/baritone/utils/io/VarIntUtils.java
+++ b/src/main/java/baritone/utils/io/VarIntUtils.java
@@ -1,0 +1,56 @@
+package baritone.utils.io;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Utility helpers for encoding and decoding little-endian style base-128 varints.
+ * This is tailored for compact chunk blobs that need to be parsed from {@link ByteBuffer}s
+ * without allocations.
+ */
+public final class VarIntUtils {
+
+    private VarIntUtils() {
+    }
+
+    public static void writeUnsigned(ByteArrayOutputStream out, int value) {
+        int v = value;
+        while ((v & 0xFFFFFF80) != 0L) {
+            out.write((v & 0x7F) | 0x80);
+            v >>>= 7;
+        }
+        out.write(v & 0x7F);
+    }
+
+    public static void writeZigZag(ByteArrayOutputStream out, int value) {
+        writeUnsigned(out, encodeZigZag32(value));
+    }
+
+    public static int readUnsigned(ByteBuffer buffer) {
+        int value = 0;
+        int shift = 0;
+        while (true) {
+            byte b = buffer.get();
+            value |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return value;
+            }
+            shift += 7;
+            if (shift >= 35) {
+                throw new IllegalArgumentException("VarInt too large");
+            }
+        }
+    }
+
+    public static int readZigZag(ByteBuffer buffer) {
+        return decodeZigZag32(readUnsigned(buffer));
+    }
+
+    public static int encodeZigZag32(int value) {
+        return (value << 1) ^ (value >> 31);
+    }
+
+    public static int decodeZigZag32(int value) {
+        return (value >>> 1) ^ -(value & 1);
+    }
+}

--- a/src/main/java/baritone/utils/pathing/Favoring.java
+++ b/src/main/java/baritone/utils/pathing/Favoring.java
@@ -52,4 +52,8 @@ public final class Favoring {
     public double calculate(long hash) {
         return favorings.get(hash);
     }
+
+    public void multiply(long hash, double coefficient) {
+        favorings.put(hash, favorings.get(hash) * coefficient);
+    }
 }


### PR DESCRIPTION
## Summary
- add a pluggable block compression API with deflate fallback and helpers for packed height, passability, and vertical band fields
- implement chunk and region summary packing with micro-index metadata plus a concurrent seed summary manager
- introduce a CPU-first predictive planner that runs weighted A* over macro tiles using the compressed summaries

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_b_68d7bcf97cd4832fa279dc55572ea9b1