### PR TITLE
Add automatic eating controls and item use helper

### DIFF
--- a/src/api/java/baritone/api/IBaritone.java
+++ b/src/api/java/baritone/api/IBaritone.java
@@ -28,6 +28,7 @@ import baritone.api.pathing.seed.ISeedPathing;
 import baritone.api.process.*;
 import baritone.api.selection.ISelectionManager;
 import baritone.api.utils.IInputOverrideHandler;
+import baritone.api.utils.IItemUseHelper;
 import baritone.api.utils.IPlayerContext;
 
 /**
@@ -103,6 +104,11 @@ public interface IBaritone {
     IElytraProcess getElytraProcess();
 
     /**
+     * @return The {@link IAutoEatProcess} instance
+     */
+    IAutoEatProcess getAutoEatProcess();
+
+    /**
      * @return The {@link IWorldProvider} instance
      * @see IWorldProvider
      */
@@ -122,6 +128,11 @@ public interface IBaritone {
      * @see IInputOverrideHandler
      */
     IInputOverrideHandler getInputOverrideHandler();
+
+    /**
+     * @return Helper utilities for interacting with held items.
+     */
+    IItemUseHelper getItemUseHelper();
 
     /**
      * @return The {@link IPlayerContext} instance

--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -93,6 +93,16 @@ public final class Settings {
     public final Setting<Boolean> allowInventory = new Setting<>(false);
 
     /**
+     * Automatically eat food when the player's hunger drops below the configured threshold.
+     */
+    public final Setting<Boolean> autoEat = new Setting<>(false);
+
+    /**
+     * The hunger level that will trigger automatic eating when {@link #autoEat} is enabled.
+     */
+    public final Setting<Integer> autoEatThreshold = new Setting<>(12);
+
+    /**
      * Wait this many ticks between InventoryBehavior moving inventory items
      */
     public final Setting<Integer> ticksBetweenInventoryMoves = new Setting<>(1);

--- a/src/api/java/baritone/api/process/IAutoEatProcess.java
+++ b/src/api/java/baritone/api/process/IAutoEatProcess.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.process;
+
+/**
+ * Process responsible for managing automatic hunger refills.
+ */
+public interface IAutoEatProcess extends IBaritoneProcess {
+
+    /**
+     * @return {@code true} while Baritone is actively attempting to refill hunger.
+     */
+    boolean isEating();
+
+    /**
+     * Request that the process begins an eating cycle on the next tick where it is safe to do so,
+     * even if the configured hunger threshold has not been reached yet.
+     */
+    void requestImmediateEat();
+}

--- a/src/api/java/baritone/api/utils/IItemUseHelper.java
+++ b/src/api/java/baritone/api/utils/IItemUseHelper.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.api.utils;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.phys.BlockHitResult;
+
+import java.util.Optional;
+
+/**
+ * High level utilities for interacting with held items in a way that respects vanilla's interaction flow.
+ */
+public interface IItemUseHelper {
+
+    /**
+     * Attempts to use the held item on the specified block hit result.
+     *
+     * @param hand       The hand to use.
+     * @param hitResult  The block that should be targeted.
+     * @return {@code true} if the interaction consumed an action.
+     */
+    boolean useItemOn(InteractionHand hand, BlockHitResult hitResult);
+
+    /**
+     * Attempts to use the held item without a targeted block (right click in air).
+     *
+     * @param hand The hand to use.
+     * @return {@code true} if the interaction consumed an action.
+     */
+    boolean useItem(InteractionHand hand);
+
+    /**
+     * Requests that the current use action is released. This mirrors the vanilla client behaviour
+     * when the player releases the corresponding key.
+     */
+    void releaseUsingItem();
+
+    /**
+     * @return {@code true} if the player is currently using an item.
+     */
+    boolean isUsingItem();
+
+    /**
+     * @return The hand that is currently being used, if any.
+     */
+    Optional<InteractionHand> activeHand();
+}

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -37,6 +37,7 @@ import baritone.utils.GuiClick;
 import baritone.utils.InputOverrideHandler;
 import baritone.utils.PathingControlManager;
 import baritone.utils.player.BaritonePlayerContext;
+import baritone.utils.player.ItemUseHelper;
 import baritone.pathing.seed.SeedPredictionService;
 import net.minecraft.client.Minecraft;
 
@@ -73,6 +74,7 @@ public class Baritone implements IBaritone {
     private final HumanizationBehavior humanizationBehavior;
     private final InventoryBehavior inventoryBehavior;
     private final InputOverrideHandler inputOverrideHandler;
+    private final ItemUseHelper itemUseHelper;
 
     private final FollowProcess followProcess;
     private final MineProcess mineProcess;
@@ -82,6 +84,7 @@ public class Baritone implements IBaritone {
     private final ExploreProcess exploreProcess;
     private final FarmProcess farmProcess;
     private final InventoryPauserProcess inventoryPauserProcess;
+    private final AutoEatProcess autoEatProcess;
     private final IElytraProcess elytraProcess;
 
     private final PathingControlManager pathingControlManager;
@@ -108,6 +111,7 @@ public class Baritone implements IBaritone {
 
         // Define this before behaviors try and get it, or else it will be null and the builds will fail!
         this.playerContext = new BaritonePlayerContext(this, mc);
+        this.itemUseHelper = new ItemUseHelper(this.playerContext);
 
         {
             this.lookBehavior         = this.registerBehavior(LookBehavior::new);
@@ -127,6 +131,7 @@ public class Baritone implements IBaritone {
             this.builderProcess          = this.registerProcess(BuilderProcess::new);
             this.exploreProcess          = this.registerProcess(ExploreProcess::new);
             this.farmProcess             = this.registerProcess(FarmProcess::new);
+            this.autoEatProcess          = this.registerProcess(AutoEatProcess::new);
             this.inventoryPauserProcess  = this.registerProcess(InventoryPauserProcess::new);
             this.elytraProcess           = this.registerProcess(ElytraProcess::create);
             this.registerProcess(BackfillProcess::new);
@@ -195,6 +200,11 @@ public class Baritone implements IBaritone {
     }
 
     @Override
+    public ItemUseHelper getItemUseHelper() {
+        return this.itemUseHelper;
+    }
+
+    @Override
     public HumanizationBehavior getHumanizationBehavior() {
         return this.humanizationBehavior;
     }
@@ -221,6 +231,11 @@ public class Baritone implements IBaritone {
 
     public InventoryPauserProcess getInventoryPauserProcess() {
         return this.inventoryPauserProcess;
+    }
+
+    @Override
+    public AutoEatProcess getAutoEatProcess() {
+        return this.autoEatProcess;
     }
 
     @Override

--- a/src/main/java/baritone/command/defaults/AutoEatCommand.java
+++ b/src/main/java/baritone/command/defaults/AutoEatCommand.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.Baritone;
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+public class AutoEatCommand extends Command {
+
+    public AutoEatCommand(IBaritone baritone) {
+        super(baritone, "autoeat");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        args.requireExactly(1);
+        boolean enabled = args.getAs(Boolean.class);
+        Baritone.settings().autoEat.value = enabled;
+        logDirect(String.format(Locale.US, "Auto eat %s.", enabled ? "enabled" : "disabled"));
+        if (enabled && ctx.player() != null && ctx.player().getFoodData().getFoodLevel() <= Baritone.settings().autoEatThreshold.value) {
+            baritone.getAutoEatProcess().requestImmediateEat();
+        }
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) throws CommandException {
+        if (args.hasExactlyOne()) {
+            String prefix = args.peekString().toLowerCase(Locale.US);
+            return Stream.of("true", "false").filter(option -> option.startsWith(prefix));
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Toggle automatic hunger refills";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "The autoeat command toggles automatic hunger refills.",
+                "",
+                "Usage:",
+                "> autoeat <true|false> - Enables or disables automatic eating."
+        );
+    }
+}

--- a/src/main/java/baritone/command/defaults/AutoEatThresholdCommand.java
+++ b/src/main/java/baritone/command/defaults/AutoEatThresholdCommand.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.Baritone;
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+public class AutoEatThresholdCommand extends Command {
+
+    private static final int MAX_FOOD_LEVEL = 20;
+
+    public AutoEatThresholdCommand(IBaritone baritone) {
+        super(baritone, "autoeatthreshold");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        args.requireExactly(1);
+        int requested = args.getAs(Integer.class);
+        int clamped = Math.max(0, Math.min(MAX_FOOD_LEVEL, requested));
+        Baritone.settings().autoEatThreshold.value = clamped;
+        logDirect(String.format(Locale.US, "Auto eat threshold set to %d.", clamped));
+        if (clamped != requested) {
+            logDirect(String.format(Locale.US, "Value clamped to the valid hunger range of 0-%d.", MAX_FOOD_LEVEL));
+        }
+        if (Baritone.settings().autoEat.value && ctx.player() != null && ctx.player().getFoodData().getFoodLevel() <= clamped) {
+            baritone.getAutoEatProcess().requestImmediateEat();
+        }
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Configure the hunger threshold for automatic eating";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "The autoeatthreshold command sets the hunger level where automatic eating starts.",
+                "",
+                "Usage:",
+                "> autoeatthreshold <level> - Sets the trigger level (0-20)."
+        );
+    }
+}

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -51,6 +51,8 @@ public final class DefaultCommands {
                 new ForceCancelCommand(baritone),
                 new GcCommand(baritone),
                 new InvertCommand(baritone),
+                new AutoEatCommand(baritone),
+                new AutoEatThresholdCommand(baritone),
                 new TunnelCommand(baritone),
                 new RenderCommand(baritone),
                 new FarmCommand(baritone),

--- a/src/main/java/baritone/process/AutoEatProcess.java
+++ b/src/main/java/baritone/process/AutoEatProcess.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.process;
+
+import baritone.Baritone;
+import baritone.api.Settings;
+import baritone.api.process.IAutoEatProcess;
+import baritone.api.process.PathingCommand;
+import baritone.api.process.PathingCommandType;
+import baritone.api.utils.IItemUseHelper;
+import baritone.api.utils.input.Input;
+import baritone.utils.BaritoneProcessHelper;
+import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.OptionalInt;
+
+public final class AutoEatProcess extends BaritoneProcessHelper implements IAutoEatProcess {
+
+    private static final int MAX_FOOD_LEVEL = 20;
+
+    private boolean refilling;
+    private boolean manualTrigger;
+    private boolean announcedNoFood;
+    private int selectedSlot = -1;
+
+    public AutoEatProcess(Baritone baritone) {
+        super(baritone);
+    }
+
+    @Override
+    public boolean isActive() {
+        Player player = ctx.player();
+        if (player == null || ctx.world() == null) {
+            return false;
+        }
+        if (player.isCreative()) {
+            return false;
+        }
+        if (refilling || manualTrigger) {
+            return true;
+        }
+        if (!Baritone.settings().autoEat.value) {
+            return false;
+        }
+        return player.getFoodData().getFoodLevel() <= Baritone.settings().autoEatThreshold.value && hasEdibleInHotbar(player);
+    }
+
+    @Override
+    public PathingCommand onTick(boolean calcFailed, boolean isSafeToCancel) {
+        Player player = ctx.player();
+        if (player == null || ctx.world() == null || player.isCreative()) {
+            stopEating();
+            return new PathingCommand(null, PathingCommandType.DEFER);
+        }
+
+        final Settings settings = Baritone.settings();
+        final int hunger = player.getFoodData().getFoodLevel();
+        final boolean thresholdReached = settings.autoEat.value && hunger <= settings.autoEatThreshold.value;
+
+        if (!refilling && (manualTrigger || thresholdReached)) {
+            refilling = true;
+        }
+
+        if (!refilling) {
+            stopEating();
+            return new PathingCommand(null, PathingCommandType.DEFER);
+        }
+
+        if (hunger >= MAX_FOOD_LEVEL && !player.isUsingItem()) {
+            stopEating();
+            return new PathingCommand(null, PathingCommandType.DEFER);
+        }
+
+        OptionalInt nextFoodSlot = findFoodSlot(player);
+        if (nextFoodSlot.isEmpty() && !player.isUsingItem()) {
+            if (!announcedNoFood) {
+                logDirect("Auto eat paused - no edible items in hotbar.");
+                announcedNoFood = true;
+            }
+            stopEating();
+            return new PathingCommand(null, PathingCommandType.DEFER);
+        }
+        announcedNoFood = false;
+
+        if (!player.isUsingItem()) {
+            if (!isSafeToCancel) {
+                baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, false);
+                return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+            }
+            nextFoodSlot.ifPresent(slot -> {
+                if (selectedSlot != slot) {
+                    player.getInventory().setSelectedSlot(slot);
+                    ctx.playerController().syncHeldItem();
+                    selectedSlot = slot;
+                }
+            });
+            baritone.getInputOverrideHandler().setInputForceState(Input.SPRINT, false);
+            baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+            IItemUseHelper itemUseHelper = baritone.getItemUseHelper();
+            itemUseHelper.useItem(InteractionHand.MAIN_HAND);
+            manualTrigger = false;
+        } else {
+            manualTrigger = false;
+            baritone.getInputOverrideHandler().setInputForceState(Input.SPRINT, false);
+            baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, true);
+        }
+
+        return new PathingCommand(null, PathingCommandType.REQUEST_PAUSE);
+    }
+
+    @Override
+    public void onLostControl() {
+        stopEating();
+    }
+
+    @Override
+    public String displayName0() {
+        return "auto eat";
+    }
+
+    @Override
+    public boolean isTemporary() {
+        return true;
+    }
+
+    @Override
+    public double priority() {
+        return 5.6;
+    }
+
+    @Override
+    public boolean isEating() {
+        Player player = ctx.player();
+        return refilling || (player != null && player.isUsingItem());
+    }
+
+    @Override
+    public void requestImmediateEat() {
+        manualTrigger = true;
+    }
+
+    private OptionalInt findFoodSlot(Player player) {
+        NonNullList<ItemStack> items = player.getInventory().getNonEquipmentItems();
+        for (int i = 0; i < Math.min(items.size(), 9); i++) {
+            ItemStack stack = items.get(i);
+            if (isEdible(stack)) {
+                return OptionalInt.of(i);
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    private boolean hasEdibleInHotbar(Player player) {
+        return findFoodSlot(player).isPresent();
+    }
+
+    private boolean isEdible(ItemStack stack) {
+        return !stack.isEmpty() && stack.get(DataComponents.FOOD) != null;
+    }
+
+    private void stopEating() {
+        refilling = false;
+        manualTrigger = false;
+        selectedSlot = -1;
+        announcedNoFood = false;
+        baritone.getInputOverrideHandler().setInputForceState(Input.CLICK_RIGHT, false);
+        IItemUseHelper helper = baritone.getItemUseHelper();
+        if (helper.isUsingItem()) {
+            helper.releaseUsingItem();
+        }
+    }
+}

--- a/src/main/java/baritone/utils/player/ItemUseHelper.java
+++ b/src/main/java/baritone/utils/player/ItemUseHelper.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.utils.player;
+
+import baritone.api.utils.IItemUseHelper;
+import baritone.api.utils.IPlayerContext;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.phys.BlockHitResult;
+
+import java.util.Optional;
+
+/**
+ * Client side helper that mirrors vanilla item usage rules to keep behaviour consistent across
+ * different interaction types.
+ */
+public final class ItemUseHelper implements IItemUseHelper {
+
+    private final IPlayerContext ctx;
+
+    public ItemUseHelper(IPlayerContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public boolean useItemOn(InteractionHand hand, BlockHitResult hitResult) {
+        LocalPlayer player = ctx.player();
+        if (player == null || ctx.world() == null || ctx.minecraft().gameMode == null) {
+            return false;
+        }
+        InteractionResult result = ctx.playerController().processRightClickBlock(player, ctx.world(), hand, hitResult);
+        if (result.consumesAction()) {
+            player.swing(hand);
+        }
+        return result.consumesAction();
+    }
+
+    @Override
+    public boolean useItem(InteractionHand hand) {
+        LocalPlayer player = ctx.player();
+        if (player == null || ctx.world() == null || ctx.minecraft().gameMode == null) {
+            return false;
+        }
+        InteractionResult result = ctx.playerController().processRightClick(player, ctx.world(), hand);
+        if (result.consumesAction()) {
+            player.swing(hand);
+        }
+        return result.consumesAction();
+    }
+
+    @Override
+    public void releaseUsingItem() {
+        LocalPlayer player = ctx.player();
+        if (player == null) {
+            return;
+        }
+        if (ctx.minecraft().gameMode != null) {
+            ctx.minecraft().gameMode.releaseUsingItem(player);
+        } else {
+            player.releaseUsingItem();
+        }
+    }
+
+    @Override
+    public boolean isUsingItem() {
+        LocalPlayer player = ctx.player();
+        return player != null && player.isUsingItem();
+    }
+
+    @Override
+    public Optional<InteractionHand> activeHand() {
+        LocalPlayer player = ctx.player();
+        if (player == null || !player.isUsingItem()) {
+            return Optional.empty();
+        }
+        return Optional.of(player.getUsedItemHand());
+    }
+}


### PR DESCRIPTION
## Summary
- add auto-eat settings, commands, and a dedicated process that pauses pathing while hunger is refilled
- expose an item use helper API and register it on the Baritone instance so other systems can trigger vanilla-compliant item interactions

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_b_68d7e9e55e48832f9a87c182a4049278