### PR TITLE
Add behaviors to support auto-eat coordination and expose kill command

### DIFF
--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -119,6 +119,8 @@ public class Baritone implements IBaritone {
             this.inventoryBehavior    = this.registerBehavior(InventoryBehavior::new);
             this.inputOverrideHandler = this.registerBehavior(InputOverrideHandler::new);
             this.humanizationBehavior = this.registerBehavior(HumanizationBehavior::new);
+            this.registerBehavior(AutoEatBehavior::new);
+            this.registerBehavior(PathRepairBehavior::new);
             this.registerBehavior(WaypointBehavior::new);
         }
 

--- a/src/main/java/baritone/behavior/AutoEatBehavior.java
+++ b/src/main/java/baritone/behavior/AutoEatBehavior.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior;
+
+import baritone.Baritone;
+import baritone.api.event.events.TickEvent;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Coordinates automatic eating with the shared Baritone state so that
+ * manual triggers and combat safety checks can coexist with pathing.
+ */
+public final class AutoEatBehavior extends Behavior {
+
+    public AutoEatBehavior(Baritone baritone) {
+        super(baritone);
+    }
+
+    @Override
+    public void onTick(TickEvent event) {
+        if (event.getType() != TickEvent.Type.IN) {
+            return;
+        }
+
+        Player player = ctx.player();
+        if (player == null || ctx.world() == null || player.isCreative()) {
+            return;
+        }
+
+        if (!Baritone.settings().autoEat.value) {
+            return;
+        }
+
+        boolean hungerLow = player.getFoodData().getFoodLevel() <= Baritone.settings().autoEatThreshold.value;
+        boolean healthLow = player.getHealth() <= Baritone.settings().combatEatHpThreshold.value;
+
+        if ((hungerLow || healthLow) && !baritone.getAutoEatProcess().isEating()) {
+            baritone.getAutoEatProcess().requestImmediateEat();
+        }
+    }
+}

--- a/src/main/java/baritone/behavior/PathRepairBehavior.java
+++ b/src/main/java/baritone/behavior/PathRepairBehavior.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.behavior;
+
+import baritone.Baritone;
+import baritone.api.event.events.BlockChangeEvent;
+import baritone.api.pathing.calc.IPath;
+import baritone.api.utils.BetterBlockPos;
+import baritone.api.utils.Pair;
+import net.minecraft.core.BlockPos;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Monitors block change notifications so that any mutations along the
+ * currently executing path can trigger a safe revalidation.
+ */
+public final class PathRepairBehavior extends Behavior {
+
+    public PathRepairBehavior(Baritone baritone) {
+        super(baritone);
+    }
+
+    @Override
+    public void onBlockChange(BlockChangeEvent event) {
+        if (!baritone.getPathingBehavior().isPathing()) {
+            return;
+        }
+
+        IPath currentPath = baritone.getPathingBehavior().getPath().orElse(null);
+        if (currentPath == null || currentPath.length() == 0) {
+            return;
+        }
+
+        Set<Long> changed = new HashSet<>();
+        for (Pair<BlockPos, ?> pair : event.getBlocks()) {
+            BlockPos pos = pair.first();
+            changed.add(BetterBlockPos.longHash(pos.getX(), pos.getY(), pos.getZ()));
+        }
+
+        boolean intersects = currentPath.positions().stream()
+                .map(BetterBlockPos::longHash)
+                .anyMatch(changed::contains);
+
+        if (intersects) {
+            baritone.getPathingBehavior().softCancelIfSafe();
+        }
+    }
+}

--- a/src/main/java/baritone/command/defaults/DefaultCommands.java
+++ b/src/main/java/baritone/command/defaults/DefaultCommands.java
@@ -49,6 +49,7 @@ public final class DefaultCommands {
                 new ComeCommand(baritone),
                 new AxisCommand(baritone),
                 new ForceCancelCommand(baritone),
+                new KillCommand(baritone),
                 new GcCommand(baritone),
                 new InvertCommand(baritone),
                 new AutoEatCommand(baritone),

--- a/src/main/java/baritone/command/defaults/KillCommand.java
+++ b/src/main/java/baritone/command/defaults/KillCommand.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.command.defaults;
+
+import baritone.api.IBaritone;
+import baritone.api.command.Command;
+import baritone.api.command.argument.IArgConsumer;
+import baritone.api.command.exception.CommandException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Stops every running Baritone process so that the player can take
+ * manual control for combat or other emergency situations.
+ */
+public final class KillCommand extends Command {
+
+    public KillCommand(IBaritone baritone) {
+        super(baritone, "kill");
+    }
+
+    @Override
+    public void execute(String label, IArgConsumer args) throws CommandException {
+        args.requireMax(0);
+        baritone.getPathingBehavior().forceCancel();
+        baritone.getInputOverrideHandler().clearAllKeys();
+        logDirect("All Baritone activity halted. Manual control restored.");
+    }
+
+    @Override
+    public Stream<String> tabComplete(String label, IArgConsumer args) {
+        return Stream.empty();
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Halts Baritone so you can fight manually.";
+    }
+
+    @Override
+    public List<String> getLongDesc() {
+        return Arrays.asList(
+                "Stops every running Baritone process and releases forced inputs.",
+                "",
+                "Usage:",
+                "> kill"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated behaviors for auto eating and path repair that work with the updated API
- expose a simple `kill` command that halts Baritone and releases forced inputs
- register the new behaviors and command with the core Baritone bootstrapper

## Testing
- Attempted `./gradlew compileJava` (hangs in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68d8e4b9c174832fa4de5842343c4c03