### PR TITLE
Add seed pregen pipeline and commands

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -17,6 +17,7 @@
 
 package baritone.api;
 
+import baritone.api.pathing.seed.SeedOreMode;
 import baritone.api.utils.Helper;
 import baritone.api.utils.NotificationHelper;
 import baritone.api.utils.SettingsUtil;
@@ -193,6 +194,16 @@ public final class Settings {
      * Tracks whether a predictive planning seed has been explicitly provided by the user.
      */
     public final Setting<Boolean> seedPredictionSeedConfigured = new Setting<>(false);
+
+    /**
+     * Radius in chunks around the player that should be pre-generated using the configured seed.
+     */
+    public final Setting<Integer> seedPredictionPregenRadius = new Setting<>(6);
+
+    /**
+     * Controls whether predictive sections should include heuristic ore markings.
+     */
+    public final Setting<SeedOreMode> seedPredictionOreMode = new Setting<>(SeedOreMode.TERRAIN_ONLY);
 
     /**
      * Allows overriding the world seed used for all predictive systems, such as macro planning or seed cracking.

--- a/src/api/java/baritone/api/pathing/seed/ISeedPathing.java
+++ b/src/api/java/baritone/api/pathing/seed/ISeedPathing.java
@@ -58,4 +58,28 @@ public interface ISeedPathing {
      * @return {@code true} if predictive planning will be active after applying the requested state
      */
     boolean setPredictionEnabled(boolean enabled);
+
+    /**
+     * @return the configured pre-generation radius in chunks.
+     */
+    int pregenRadius();
+
+    /**
+     * Update the pre-generation radius.
+     *
+     * @param radius the radius in chunks, clamped to an implementation-defined range
+     */
+    void setPregenRadius(int radius);
+
+    /**
+     * @return the active ore enrichment mode used when generating predictive sections.
+     */
+    SeedOreMode generationMode();
+
+    /**
+     * Configure which ore enrichment mode should be used when generating predictive sections.
+     *
+     * @param mode the desired ore mode
+     */
+    void setGenerationMode(SeedOreMode mode);
 }

--- a/src/api/java/baritone/api/pathing/seed/SeedOreMode.java
+++ b/src/api/java/baritone/api/pathing/seed/SeedOreMode.java
@@ -1,0 +1,19 @@
+package baritone.api.pathing.seed;
+
+import java.util.Locale;
+
+public enum SeedOreMode {
+    TERRAIN_ONLY,
+    TERRAIN_PLUS_VEINS,
+    TERRAIN_PLUS_EXACT_ORES;
+
+    public static SeedOreMode fromString(String literal) {
+        String normalized = literal.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "TERRAIN_ONLY", "TERRAIN" -> TERRAIN_ONLY;
+            case "VEINS", "TERRAIN_PLUS_VEINS", "TERRAIN_VEINS" -> TERRAIN_PLUS_VEINS;
+            case "ORES", "TERRAIN_PLUS_EXACT_ORES", "EXACT" -> TERRAIN_PLUS_EXACT_ORES;
+            default -> throw new IllegalArgumentException("Unknown seed ore mode: " + literal);
+        };
+    }
+}

--- a/src/main/java/baritone/command/defaults/SeedCommand.java
+++ b/src/main/java/baritone/command/defaults/SeedCommand.java
@@ -23,6 +23,7 @@ import baritone.api.command.argument.IArgConsumer;
 import baritone.api.command.exception.CommandException;
 import baritone.api.command.exception.CommandInvalidTypeException;
 import baritone.api.pathing.seed.ISeedPathing;
+import baritone.api.pathing.seed.SeedOreMode;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,6 +47,8 @@ public final class SeedCommand extends Command {
             } else {
                 logDirect("No predictive seed configured.");
             }
+            logDirect("Pregen radius: " + seedPathing.pregenRadius() + " chunks");
+            logDirect("Ore mode: " + seedPathing.generationMode().name().toLowerCase(Locale.ROOT));
             return;
         }
         String action = args.getString().toLowerCase(Locale.US);
@@ -67,6 +70,32 @@ public final class SeedCommand extends Command {
                 args.requireMax(0);
                 seedPathing.clearSeed();
                 logDirect("Cleared predictive planning seed.");
+            }
+            case "radius" -> {
+                args.requireMin(1);
+                String literal = args.getString();
+                int radius;
+                try {
+                    radius = Integer.parseInt(literal);
+                } catch (NumberFormatException ex) {
+                    throw new CommandInvalidTypeException(args.consumed(), "a valid radius", literal);
+                }
+                args.requireMax(0);
+                seedPathing.setPregenRadius(radius);
+                logDirect("Predictive pregen radius set to " + seedPathing.pregenRadius() + " chunks.");
+            }
+            case "mode" -> {
+                args.requireMin(1);
+                String literal = args.getString();
+                SeedOreMode mode;
+                try {
+                    mode = SeedOreMode.fromString(literal);
+                } catch (IllegalArgumentException ex) {
+                    throw new CommandInvalidTypeException(args.consumed(), "a valid ore mode", literal);
+                }
+                args.requireMax(0);
+                seedPathing.setGenerationMode(mode);
+                logDirect("Predictive ore mode set to " + mode.name().toLowerCase(Locale.ROOT) + ".");
             }
             default -> throw new CommandInvalidTypeException(args.consumed(), "a valid seed action", action);
         }
@@ -90,7 +119,9 @@ public final class SeedCommand extends Command {
                 "Usage:",
                 "> seed - show the currently configured seed",
                 "> seed set <seed> - configure the world seed for predictive planning",
-                "> seed clear - remove the configured predictive seed"
+                "> seed clear - remove the configured predictive seed",
+                "> seed radius <chunks> - update the predictive pre-generation radius",
+                "> seed mode <terrain|veins|ores> - control ore enrichment while pre-generating"
         );
     }
 }

--- a/src/main/java/baritone/pathing/seed/SeedPredictionService.java
+++ b/src/main/java/baritone/pathing/seed/SeedPredictionService.java
@@ -7,19 +7,32 @@ import baritone.api.pathing.goals.Goal;
 import baritone.api.pathing.goals.GoalXZ;
 import baritone.api.pathing.goals.GoalYLevel;
 import baritone.api.pathing.seed.ISeedPathing;
+import baritone.api.pathing.seed.SeedOreMode;
 import baritone.api.utils.BetterBlockPos;
 import baritone.api.utils.interfaces.IGoalRenderPos;
 import baritone.api.event.events.ChunkEvent;
 import baritone.api.event.events.type.EventState;
 import baritone.api.event.listener.AbstractGameEventListener;
+import baritone.api.event.events.TickEvent;
+import baritone.api.event.events.WorldEvent;
 import baritone.cache.seed.DeflateBlockCompressor;
 import baritone.cache.seed.RegionLayout;
 import baritone.cache.seed.SeedSummaryManager;
 import baritone.cache.seed.SurfaceMetrics;
+import baritone.pathing.seed.pregen.GeneratorContext;
+import baritone.pathing.seed.pregen.SectionPregenQueue;
+import baritone.pathing.seed.pregen.SectionStore;
 import baritone.pathing.movement.CalculationContext;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.pathing.Favoring;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.entity.Mob;
@@ -29,14 +42,20 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.util.Mth;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static baritone.pathing.movement.MovementHelper.canWalkOn;
 import static baritone.pathing.movement.MovementHelper.canWalkThrough;
@@ -53,16 +72,25 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
 
     private volatile boolean enabled;
     private volatile Long configuredSeed;
+    private final ExecutorService pregenExecutor;
+    private volatile GeneratorContext generatorContext;
+    private volatile SectionStore sectionStore;
+    private volatile SeedOreMode oreMode;
+    private volatile int pregenRadius;
 
     public SeedPredictionService(Baritone baritone) {
         this.baritone = baritone;
         this.summaries = new SeedSummaryManager(new DeflateBlockCompressor());
         Settings settings = Baritone.settings();
         this.planner = new PredictivePathPlanner(summaries, settings);
+        this.pregenExecutor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors() - 1));
         if (settings.seedPredictionSeedConfigured.value) {
             this.configuredSeed = settings.seedPredictionSeed.value;
         }
         this.enabled = settings.seedBasedPrediction.value && configuredSeed != null;
+        this.oreMode = settings.seedPredictionOreMode.value;
+        this.pregenRadius = clampRadius(settings.seedPredictionPregenRadius.value);
+        SectionPregenQueue.init(pregenExecutor, null);
     }
 
     @Override
@@ -87,6 +115,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         if (settings.seedBasedPrediction.value) {
             this.enabled = true;
         }
+        resetPregen();
     }
 
     @Override
@@ -98,6 +127,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         cache.set(null);
         enabled = false;
         settings.seedBasedPrediction.value = false;
+        resetPregen();
     }
 
     @Override
@@ -116,8 +146,34 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         Baritone.settings().seedBasedPrediction.value = enabled;
         if (!enabled) {
             cache.set(null);
+            resetPregen();
         }
         return isPredictionEnabled();
+    }
+
+    @Override
+    public int pregenRadius() {
+        return pregenRadius;
+    }
+
+    @Override
+    public void setPregenRadius(int radius) {
+        int clamped = clampRadius(radius);
+        this.pregenRadius = clamped;
+        Baritone.settings().seedPredictionPregenRadius.value = clamped;
+        SectionPregenQueue.init(pregenExecutor, sectionStore);
+    }
+
+    @Override
+    public SeedOreMode generationMode() {
+        return oreMode;
+    }
+
+    @Override
+    public void setGenerationMode(SeedOreMode mode) {
+        this.oreMode = mode != null ? mode : SeedOreMode.TERRAIN_ONLY;
+        Baritone.settings().seedPredictionOreMode.value = this.oreMode;
+        SectionPregenQueue.init(pregenExecutor, sectionStore);
     }
 
     public void applySeedFavoring(BetterBlockPos start, Goal goal, Favoring favoring, CalculationContext context, IPath previous) {
@@ -141,6 +197,22 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
     }
 
     @Override
+    public void onTick(TickEvent event) {
+        if (event.getType() != TickEvent.Type.IN || event.getState() != EventState.POST) {
+            return;
+        }
+        tickPregen();
+    }
+
+    @Override
+    public void onWorldEvent(WorldEvent event) {
+        AbstractGameEventListener.super.onWorldEvent(event);
+        if (event.getState() == EventState.POST) {
+            resetPregen();
+        }
+    }
+
+    @Override
     public void onChunkEvent(ChunkEvent event) {
         if (event.getState() != EventState.POST) {
             return;
@@ -160,6 +232,72 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
                 summaries.overrideSurfaceMetrics(event.getX(), event.getZ(), metrics);
             }
         }
+    }
+
+    private void tickPregen() {
+        if (!isPredictionEnabled()) {
+            return;
+        }
+        Long seed = configuredSeed;
+        if (seed == null) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        if (level == null || minecraft.player == null) {
+            return;
+        }
+        ensureGeneratorContext(seed, level);
+        if (generatorContext == null || sectionStore == null) {
+            return;
+        }
+        int chunkX = minecraft.player.getBlockX() >> 4;
+        int chunkZ = minecraft.player.getBlockZ() >> 4;
+        SectionPregenQueue.queueAround(generatorContext, chunkX, chunkZ, pregenRadius, oreMode);
+    }
+
+    private void ensureGeneratorContext(long seed, ClientLevel level) {
+        if (generatorContext != null) {
+            return;
+        }
+        RegistryAccess registries = level.registryAccess();
+        Registry<NoiseGeneratorSettings> noiseSettings = registries.lookupOrThrow(Registries.NOISE_SETTINGS);
+        NoiseGeneratorSettings settingsValue = noiseSettings.getOptional(NoiseGeneratorSettings.OVERWORLD)
+                .or(() -> noiseSettings.stream().findFirst())
+                .orElse(null);
+        if (settingsValue == null) {
+            return;
+        }
+        Holder<NoiseGeneratorSettings> holder = Holder.direct(settingsValue);
+        RandomState randomState = RandomState.create(settingsValue, registries.lookupOrThrow(Registries.NOISE), seed);
+        Path saveRoot = resolveSaveRoot(level);
+        generatorContext = new GeneratorContext(seed, registries, holder, randomState,
+                level.dimensionTypeRegistration(), level.dimension(), saveRoot);
+        sectionStore = new SectionStore(saveRoot);
+        SectionPregenQueue.init(pregenExecutor, sectionStore);
+    }
+
+    private Path resolveSaveRoot(ClientLevel level) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ServerData server = minecraft.getCurrentServer();
+        String serverId = server != null ? server.ip : "singleplayer";
+        serverId = serverId.replace(':', '_');
+        String dimensionId = level.dimension().location().toString().replace(':', '_');
+        return minecraft.gameDirectory.toPath()
+                .resolve("baritone")
+                .resolve("seed-pregen")
+                .resolve(serverId)
+                .resolve(dimensionId);
+    }
+
+    private void resetPregen() {
+        generatorContext = null;
+        sectionStore = null;
+        SectionPregenQueue.init(pregenExecutor, null);
+    }
+
+    private int clampRadius(int radius) {
+        return Mth.clamp(radius, 0, 32);
     }
 
     private List<BetterBlockPos> planMacroPath(BetterBlockPos start, BetterBlockPos goal, boolean preferUnderground) {

--- a/src/main/java/baritone/pathing/seed/pregen/GeneratorContext.java
+++ b/src/main/java/baritone/pathing/seed/pregen/GeneratorContext.java
@@ -1,0 +1,22 @@
+package baritone.pathing.seed.pregen;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraft.world.level.levelgen.RandomState;
+
+import java.nio.file.Path;
+
+public record GeneratorContext(
+        long seed,
+        RegistryAccess registries,
+        Holder<NoiseGeneratorSettings> noiseSettings,
+        RandomState randomState,
+        Holder<DimensionType> dimensionType,
+        ResourceKey<Level> dimensionKey,
+        Path saveRoot
+) {
+}

--- a/src/main/java/baritone/pathing/seed/pregen/OrePlacementRunner.java
+++ b/src/main/java/baritone/pathing/seed/pregen/OrePlacementRunner.java
@@ -1,0 +1,144 @@
+package baritone.pathing.seed.pregen;
+
+import net.minecraft.world.level.levelgen.NoiseRouter;
+
+import java.util.Random;
+
+public final class OrePlacementRunner {
+
+    private OrePlacementRunner() {
+    }
+
+    public static void placeExactOres(GeneratorContext ctx, int chunkX, int sectionY, int chunkZ, byte[] categories) {
+        NoiseRouter router = ctx.randomState().router();
+        TrilinearSampler toggleSampler = new TrilinearSampler(
+                ctx.randomState(),
+                router.veinToggle(),
+                router.veinRidged(),
+                router.veinGap(),
+                router.lavaNoise(),
+                chunkX,
+                sectionY,
+                chunkZ
+        );
+        TrilinearSampler densitySampler = new TrilinearSampler(
+                ctx.randomState(),
+                router.finalDensity(),
+                router.barrierNoise(),
+                router.fluidLevelFloodednessNoise(),
+                router.lavaNoise(),
+                chunkX,
+                sectionY,
+                chunkZ
+        );
+
+        long baseSeed = ctx.seed() ^ ((long) chunkX * 341873128712L) ^ ((long) chunkZ * 132897987541L);
+        Random coarseRandom = new Random(baseSeed);
+
+        int index = 0;
+        for (int y = 0; y < 16; y++) {
+            int worldY = (sectionY << 4) + y;
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++, index++) {
+                    if (categories[index] != SectionGenerator.SOLID) {
+                        continue;
+                    }
+                    double density = densitySampler.finalDensityAt(x, y, z);
+                    if (density <= 0.0D) {
+                        continue;
+                    }
+                    double toggle = toggleSampler.finalDensityAt(x, y, z);
+                    double ridged = toggleSampler.aquiferAt(x, y, z).isWater() ? 1.0D : -1.0D;
+                    double gap = Math.abs(toggleSampler.aquiferAt(x, y, z).isLava() ? 1.0D : 0.0D);
+                    if (gap > 0.6D) {
+                        continue;
+                    }
+                    int worldX = (chunkX << 4) + x;
+                    int worldZ = (chunkZ << 4) + z;
+                    double noise = hashedNoise(baseSeed, worldX, worldY, worldZ);
+                    byte category = selectOreCategory(worldY, toggle, ridged, noise, coarseRandom);
+                    if (category != SectionGenerator.SOLID) {
+                        categories[index] = category;
+                    }
+                }
+            }
+        }
+    }
+
+    private static double hashedNoise(long seed, int x, int y, int z) {
+        long value = seed;
+        value ^= x * 0x632BE59BD9B4E019L;
+        value ^= y * 0x9E3779B97F4A7C15L;
+        value ^= z * 0xC2B2AE3D27D4EB4FL;
+        value ^= Long.rotateLeft(value, 13);
+        value *= 0x9E3779B97F4A7C15L;
+        return (value >>> 11) * (1.0D / (1L << 53));
+    }
+
+    private static byte selectOreCategory(int worldY, double toggle, double ridged, double noise, Random random) {
+        boolean deepslate = worldY < 0;
+        int absY = Math.abs(worldY);
+        double bias = toggle * 0.6D + ridged * 0.2D + (noise - 0.5D) * 0.4D;
+        if (worldY > 128 && random.nextDouble() < 0.35D) {
+            return deepslate ? SectionGenerator.O_DEEPSLATE_EMERALD : SectionGenerator.O_EMERALD;
+        }
+        if (worldY > 80) {
+            if (bias > 0.25D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_COAL : SectionGenerator.O_COAL;
+            }
+            if (bias < -0.25D && random.nextDouble() < 0.4D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_IRON : SectionGenerator.O_IRON;
+            }
+            return SectionGenerator.SOLID;
+        }
+        if (worldY > 40) {
+            if (bias > 0.15D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_COPPER : SectionGenerator.O_COPPER;
+            }
+            if (bias < -0.2D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_IRON : SectionGenerator.O_IRON;
+            }
+            if (noise > 0.75D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_COAL : SectionGenerator.O_COAL;
+            }
+            return SectionGenerator.SOLID;
+        }
+        if (worldY > 0) {
+            if (bias > 0.2D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_IRON : SectionGenerator.O_IRON;
+            }
+            if (bias < -0.15D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_GOLD : SectionGenerator.O_GOLD;
+            }
+            if (noise > 0.8D) {
+                return deepslate ? SectionGenerator.O_DEEPSLATE_REDSTONE : SectionGenerator.O_REDSTONE;
+            }
+            return SectionGenerator.SOLID;
+        }
+        if (worldY > -32) {
+            if (bias > 0.25D) {
+                return SectionGenerator.O_DEEPSLATE_DIAMOND;
+            }
+            if (bias < -0.25D) {
+                return SectionGenerator.O_DEEPSLATE_REDSTONE;
+            }
+            if (noise > 0.7D) {
+                return SectionGenerator.O_DEEPSLATE_GOLD;
+            }
+            if (noise < 0.2D) {
+                return SectionGenerator.O_DEEPSLATE_LAPIS;
+            }
+            return SectionGenerator.SOLID;
+        }
+        if (absY > 96 && random.nextDouble() < 0.3D) {
+            return SectionGenerator.O_DEEPSLATE_EMERALD;
+        }
+        if (bias > 0.15D) {
+            return SectionGenerator.O_DEEPSLATE_DIAMOND;
+        }
+        if (bias < -0.15D) {
+            return SectionGenerator.O_DEEPSLATE_LAPIS;
+        }
+        return noise > 0.6D ? SectionGenerator.O_DEEPSLATE_REDSTONE : SectionGenerator.SOLID;
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/RLEWriter.java
+++ b/src/main/java/baritone/pathing/seed/pregen/RLEWriter.java
@@ -1,0 +1,54 @@
+package baritone.pathing.seed.pregen;
+
+import java.io.ByteArrayOutputStream;
+
+public final class RLEWriter {
+
+    private final ByteArrayOutputStream output;
+    private int last = -1;
+    private int runLength = 0;
+    private int runCount = 0;
+
+    public RLEWriter(int reserve) {
+        this.output = new ByteArrayOutputStream(Math.max(0, reserve));
+    }
+
+    public void put(int value) {
+        if (value == last) {
+            runLength++;
+            return;
+        }
+        flush();
+        last = value;
+        runLength = 1;
+    }
+
+    public byte[] finish() {
+        flush();
+        return output.toByteArray();
+    }
+
+    public int runCount() {
+        return runCount;
+    }
+
+    private void flush() {
+        if (runLength == 0) {
+            return;
+        }
+        output.write((byte) last);
+        writeVarInt(runLength);
+        runCount++;
+        runLength = 0;
+        last = -1;
+    }
+
+    private void writeVarInt(int value) {
+        int current = value;
+        while ((current & 0xFFFFFF80) != 0) {
+            output.write((current & 0x7F) | 0x80);
+            current >>>= 7;
+        }
+        output.write(current & 0x7F);
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionBlob.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionBlob.java
@@ -1,0 +1,4 @@
+package baritone.pathing.seed.pregen;
+
+public record SectionBlob(int chunkX, int sectionY, int chunkZ, byte[] rleData, int runCount, int faceMask, int[] parents) {
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionConnectivity.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionConnectivity.java
@@ -1,0 +1,105 @@
+package baritone.pathing.seed.pregen;
+
+public final class SectionConnectivity {
+
+    private final int width;
+    private final int height;
+    private final int depth;
+    private final UnionFind unionFind;
+    private int faceMask;
+
+    public SectionConnectivity(int width, int height, int depth) {
+        this.width = width;
+        this.height = height;
+        this.depth = depth;
+        this.unionFind = new UnionFind(width * height * depth);
+    }
+
+    public void unionIfPassable(int x, int y, int z, boolean passable) {
+        if (!passable) {
+            return;
+        }
+        int index = index(x, y, z);
+        if (x > 0) {
+            unionFind.union(index, index(x - 1, y, z));
+        }
+        if (y > 0) {
+            unionFind.union(index, index(x, y - 1, z));
+        }
+        if (z > 0) {
+            unionFind.union(index, index(x, y, z - 1));
+        }
+        if (x == 0) {
+            faceMask |= 1 << 0;
+        }
+        if (x == width - 1) {
+            faceMask |= 1 << 1;
+        }
+        if (z == 0) {
+            faceMask |= 1 << 2;
+        }
+        if (z == depth - 1) {
+            faceMask |= 1 << 3;
+        }
+        if (y == 0) {
+            faceMask |= 1 << 4;
+        }
+        if (y == height - 1) {
+            faceMask |= 1 << 5;
+        }
+    }
+
+    public int faceMask() {
+        return faceMask;
+    }
+
+    public int[] parentsArray() {
+        return unionFind.parents();
+    }
+
+    private int index(int x, int y, int z) {
+        return (y * depth + z) * width + x;
+    }
+
+    private static final class UnionFind {
+
+        private final int[] parent;
+        private final int[] rank;
+
+        UnionFind(int size) {
+            this.parent = new int[size];
+            this.rank = new int[size];
+            for (int i = 0; i < size; i++) {
+                parent[i] = i;
+            }
+        }
+
+        int[] parents() {
+            return parent;
+        }
+
+        int find(int value) {
+            if (parent[value] == value) {
+                return value;
+            }
+            parent[value] = find(parent[value]);
+            return parent[value];
+        }
+
+        void union(int a, int b) {
+            int rootA = find(a);
+            int rootB = find(b);
+            if (rootA == rootB) {
+                return;
+            }
+            if (rank[rootA] < rank[rootB]) {
+                parent[rootA] = rootB;
+            } else if (rank[rootA] > rank[rootB]) {
+                parent[rootB] = rootA;
+            } else {
+                parent[rootB] = rootA;
+                rank[rootA]++;
+            }
+        }
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionGenerator.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionGenerator.java
@@ -1,0 +1,98 @@
+package baritone.pathing.seed.pregen;
+
+import baritone.api.pathing.seed.SeedOreMode;
+import net.minecraft.world.level.levelgen.NoiseRouter;
+
+public final class SectionGenerator {
+
+    public static final byte SOLID = 0;
+    public static final byte AIR = 1;
+    public static final byte WATER = 2;
+    public static final byte LAVA = 3;
+    public static final byte O_COAL = 4;
+    public static final byte O_IRON = 5;
+    public static final byte O_COPPER = 6;
+    public static final byte O_GOLD = 7;
+    public static final byte O_LAPIS = 8;
+    public static final byte O_DIAMOND = 9;
+    public static final byte O_REDSTONE = 10;
+    public static final byte O_EMERALD = 11;
+    public static final byte O_DEEPSLATE_COAL = 12;
+    public static final byte O_DEEPSLATE_IRON = 13;
+    public static final byte O_DEEPSLATE_COPPER = 14;
+    public static final byte O_DEEPSLATE_GOLD = 15;
+    public static final byte O_DEEPSLATE_LAPIS = 16;
+    public static final byte O_DEEPSLATE_DIAMOND = 17;
+    public static final byte O_DEEPSLATE_REDSTONE = 18;
+    public static final byte O_DEEPSLATE_EMERALD = 19;
+
+    private SectionGenerator() {
+    }
+
+    public static SectionBlob generate(GeneratorContext ctx, int cx, int sy, int cz, SeedOreMode mode) {
+        NoiseRouter router = ctx.randomState().router();
+        TrilinearSampler sampler = new TrilinearSampler(
+                ctx.randomState(),
+                router.finalDensity(),
+                router.barrierNoise(),
+                router.fluidLevelFloodednessNoise(),
+                router.lavaNoise(),
+                cx, sy, cz
+        );
+
+        byte[] categories = new byte[16 * 16 * 16];
+        int index = 0;
+        for (int y = 0; y < 16; y++) {
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++, index++) {
+                    double density = sampler.finalDensityAt(x, y, z);
+                    if (density > 0.0D) {
+                        categories[index] = SOLID;
+                        continue;
+                    }
+                    TrilinearSampler.AquiferPick aquifer = sampler.aquiferAt(x, y, z);
+                    if (aquifer.isLava()) {
+                        categories[index] = LAVA;
+                    } else if (aquifer.isWater()) {
+                        categories[index] = WATER;
+                    } else {
+                        categories[index] = AIR;
+                    }
+                }
+            }
+        }
+
+        if (mode == SeedOreMode.TERRAIN_PLUS_VEINS) {
+            VeinMarker.fastFlagVeins(ctx.randomState().router(), cx, sy, cz, categories);
+        } else if (mode == SeedOreMode.TERRAIN_PLUS_EXACT_ORES) {
+            OrePlacementRunner.placeExactOres(ctx, cx, sy, cz, categories);
+        }
+
+        RLEWriter writer = new RLEWriter(256);
+        SectionConnectivity connectivity = new SectionConnectivity(16, 16, 16);
+        index = 0;
+        for (int y = 0; y < 16; y++) {
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++, index++) {
+                    byte category = categories[index];
+                    writer.put(category);
+                    if (category == AIR || category == WATER) {
+                        connectivity.unionIfPassable(x, y, z, true);
+                    } else {
+                        connectivity.unionIfPassable(x, y, z, false);
+                    }
+                }
+            }
+        }
+
+        return new SectionBlob(
+                cx,
+                sy,
+                cz,
+                writer.finish(),
+                writer.runCount(),
+                connectivity.faceMask(),
+                connectivity.parentsArray()
+        );
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionPregenQueue.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionPregenQueue.java
@@ -1,0 +1,52 @@
+package baritone.pathing.seed.pregen;
+
+import baritone.api.pathing.seed.SeedOreMode;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+public final class SectionPregenQueue {
+
+    private static ExecutorService executor;
+    private static SectionStore store;
+    private static final Set<Long> seen = ConcurrentHashMap.newKeySet();
+
+    private SectionPregenQueue() {
+    }
+
+    public static void init(ExecutorService service, SectionStore sectionStore) {
+        executor = service;
+        store = sectionStore;
+        seen.clear();
+    }
+
+    public static void queueAround(GeneratorContext context, int playerChunkX, int playerChunkZ, int radius, SeedOreMode mode) {
+        if (executor == null || store == null) {
+            return;
+        }
+        int minChunkX = playerChunkX - radius;
+        int maxChunkX = playerChunkX + radius;
+        int minChunkZ = playerChunkZ - radius;
+        int maxChunkZ = playerChunkZ + radius;
+        int minSectionY = SectionUtil.minSectionY(context);
+        int maxSectionY = SectionUtil.maxSectionY(context);
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+                for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
+                    long key = SectionUtil.key(chunkX, sectionY, chunkZ);
+                    if (!seen.add(key)) {
+                        continue;
+                    }
+                    final int fx = chunkX;
+                    final int fy = sectionY;
+                    final int fz = chunkZ;
+                    executor.submit(() -> {
+                        SectionBlob blob = SectionGenerator.generate(context, fx, fy, fz, mode);
+                        store.write(blob);
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionStore.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionStore.java
@@ -1,0 +1,61 @@
+package baritone.pathing.seed.pregen;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public final class SectionStore {
+
+    private final Path root;
+
+    public SectionStore(Path root) {
+        this.root = root;
+    }
+
+    public void write(SectionBlob blob) {
+        try {
+            Path dimensionDir = root;
+            Files.createDirectories(dimensionDir);
+            Path directory = dimensionDir.resolve((blob.chunkX() >> 5) + "_" + (blob.chunkZ() >> 5));
+            Files.createDirectories(directory);
+            Path file = directory.resolve(blob.chunkX() + "_" + blob.sectionY() + "_" + blob.chunkZ() + ".psec");
+            try (BufferedOutputStream output = new BufferedOutputStream(Files.newOutputStream(file,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE))) {
+                writeVarInt(output, blob.chunkX());
+                writeVarInt(output, blob.sectionY());
+                writeVarInt(output, blob.chunkZ());
+                writeVarInt(output, blob.runCount());
+                writeVarInt(output, blob.faceMask());
+                byte[] rle = blob.rleData();
+                writeVarInt(output, rle.length);
+                output.write(rle);
+                int[] parents = blob.parents();
+                writeVarInt(output, parents.length);
+                ByteBuffer buffer = ByteBuffer.allocate(parents.length * Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+                for (int value : parents) {
+                    buffer.putInt(value);
+                }
+                output.write(buffer.array());
+                output.flush();
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private void writeVarInt(OutputStream output, int value) throws IOException {
+        int current = value;
+        while ((current & 0xFFFFFF80) != 0) {
+            output.write((current & 0x7F) | 0x80);
+            current >>>= 7;
+        }
+        output.write(current & 0x7F);
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionUtil.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionUtil.java
@@ -1,0 +1,24 @@
+package baritone.pathing.seed.pregen;
+
+public final class SectionUtil {
+
+    private SectionUtil() {
+    }
+
+    public static int minSectionY(GeneratorContext context) {
+        return context.noiseSettings().value().noiseSettings().minY() >> 4;
+    }
+
+    public static int maxSectionY(GeneratorContext context) {
+        int minY = context.noiseSettings().value().noiseSettings().minY();
+        int height = context.noiseSettings().value().noiseSettings().height();
+        return ((minY + height) >> 4) - 1;
+    }
+
+    public static long key(int chunkX, int sectionY, int chunkZ) {
+        long kx = (long) chunkX & 0x3FFFFFL;
+        long ky = (long) sectionY & 0x3FFL;
+        long kz = (long) chunkZ & 0x3FFFFFL;
+        return (kx << 42) | (ky << 32) | kz;
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/TrilinearSampler.java
+++ b/src/main/java/baritone/pathing/seed/pregen/TrilinearSampler.java
@@ -1,0 +1,82 @@
+package baritone.pathing.seed.pregen;
+
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.RandomState;
+
+final class TrilinearSampler {
+
+    private final RandomState state;
+    private final DensityFunction finalDensity;
+    private final DensityFunction barrier;
+    private final DensityFunction flood;
+    private final DensityFunction lava;
+    private final int baseX;
+    private final int baseY;
+    private final int baseZ;
+
+    TrilinearSampler(RandomState state,
+                     DensityFunction finalDensity,
+                     DensityFunction barrier,
+                     DensityFunction flood,
+                     DensityFunction lava,
+                     int chunkX,
+                     int sectionY,
+                     int chunkZ) {
+        this.state = state;
+        this.finalDensity = finalDensity;
+        this.barrier = barrier;
+        this.flood = flood;
+        this.lava = lava;
+        this.baseX = chunkX << 4;
+        this.baseY = sectionY << 4;
+        this.baseZ = chunkZ << 4;
+    }
+
+    double finalDensityAt(int x, int y, int z) {
+        return interpolate(finalDensity, x, y, z);
+    }
+
+    AquiferPick aquiferAt(int x, int y, int z) {
+        double lavaNoise = interpolate(lava, x, y, z);
+        double floodNoise = interpolate(flood, x, y, z);
+        double barrierNoise = interpolate(barrier, x, y, z);
+        boolean lavaFlag = lavaNoise >= 0.3D && barrierNoise < 0.0D;
+        boolean waterFlag = !lavaFlag && floodNoise > 0.0D;
+        return new AquiferPick(waterFlag, lavaFlag);
+    }
+
+    private double interpolate(DensityFunction function, int x, int y, int z) {
+        int latticeX = x >> 2;
+        int latticeY = y >> 2;
+        int latticeZ = z >> 2;
+        double dx = (x & 3) / 4.0D;
+        double dy = (y & 3) / 4.0D;
+        double dz = (z & 3) / 4.0D;
+        double c000 = sample(function, latticeX, latticeY, latticeZ);
+        double c100 = sample(function, latticeX + 1, latticeY, latticeZ);
+        double c010 = sample(function, latticeX, latticeY + 1, latticeZ);
+        double c110 = sample(function, latticeX + 1, latticeY + 1, latticeZ);
+        double c001 = sample(function, latticeX, latticeY, latticeZ + 1);
+        double c101 = sample(function, latticeX + 1, latticeY, latticeZ + 1);
+        double c011 = sample(function, latticeX, latticeY + 1, latticeZ + 1);
+        double c111 = sample(function, latticeX + 1, latticeY + 1, latticeZ + 1);
+        double c00 = c000 * (1.0D - dx) + c100 * dx;
+        double c10 = c010 * (1.0D - dx) + c110 * dx;
+        double c01 = c001 * (1.0D - dx) + c101 * dx;
+        double c11 = c011 * (1.0D - dx) + c111 * dx;
+        double c0 = c00 * (1.0D - dy) + c10 * dy;
+        double c1 = c01 * (1.0D - dy) + c11 * dy;
+        return c0 * (1.0D - dz) + c1 * dz;
+    }
+
+    private double sample(DensityFunction function, int latticeX, int latticeY, int latticeZ) {
+        int worldX = baseX + (latticeX << 2);
+        int worldY = baseY + (latticeY << 2);
+        int worldZ = baseZ + (latticeZ << 2);
+        DensityFunction.SinglePointContext context = new DensityFunction.SinglePointContext(worldX, worldY, worldZ);
+        return function.compute(context);
+    }
+
+    record AquiferPick(boolean isWater, boolean isLava) {
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/VeinMarker.java
+++ b/src/main/java/baritone/pathing/seed/pregen/VeinMarker.java
@@ -1,0 +1,51 @@
+package baritone.pathing.seed.pregen;
+
+import net.minecraft.world.level.levelgen.NoiseRouter;
+
+public final class VeinMarker {
+
+    private VeinMarker() {
+    }
+
+    public static void fastFlagVeins(NoiseRouter router, int chunkX, int sectionY, int chunkZ, byte[] categories) {
+        TrilinearSampler sampler = new TrilinearSampler(
+                null,
+                router.veinToggle(),
+                router.veinRidged(),
+                router.veinGap(),
+                router.lavaNoise(),
+                chunkX,
+                sectionY,
+                chunkZ
+        );
+
+        int index = 0;
+        for (int y = 0; y < 16; y++) {
+            int worldY = (sectionY << 4) + y;
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++, index++) {
+                    byte current = categories[index];
+                    if (current != SectionGenerator.SOLID) {
+                        continue;
+                    }
+                    double toggle = sampler.finalDensityAt(x, y, z);
+                    double ridged = sampler.aquiferAt(x, y, z).isWater() ? 1.0D : -1.0D;
+                    double weight = toggle * 0.8D + ridged * 0.2D;
+                    if (Math.abs(weight) < 0.55D) {
+                        continue;
+                    }
+                    boolean deepslate = worldY < 0;
+                    if (weight > 0.0D) {
+                        categories[index] = deepslate ? SectionGenerator.O_DEEPSLATE_IRON : SectionGenerator.O_IRON;
+                    } else {
+                        if (worldY > 48) {
+                            categories[index] = deepslate ? SectionGenerator.O_DEEPSLATE_COPPER : SectionGenerator.O_COPPER;
+                        } else {
+                            categories[index] = deepslate ? SectionGenerator.O_DEEPSLATE_GOLD : SectionGenerator.O_GOLD;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a client-side section pre-generation pipeline that samples noise, annotates ores, and stores compressed section blobs
- integrate the new pipeline into the seed prediction service with configurable radius and ore mode settings
- extend the seed command API with radius and ore mode subcommands while exposing the configuration through settings

## Testing
- ./gradlew :compileJava

------
https://chatgpt.com/codex/tasks/task_b_68d8eef43484832f8d7ff851b1f7bc7d