### PR TITLE
Add seed-based ore prediction toggle and tracking

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -206,6 +206,12 @@ public final class Settings {
     public final Setting<SeedOreMode> seedPredictionOreMode = new Setting<>(SeedOreMode.TERRAIN_ONLY);
 
     /**
+     * Ignore ore blocks provided by the server when predictive data is available and instead rely exclusively on
+     * locally generated ore predictions derived from the configured seed.
+     */
+    public final Setting<Boolean> ignoreServerOreData = new Setting<>(false);
+
+    /**
      * Allows overriding the world seed used for all predictive systems, such as macro planning or seed cracking.
      * A value of {@code 0} disables the override and defers to the server supplied seed instead.
      */

--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -18,6 +18,7 @@
 package baritone.api.utils;
 
 import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
 import baritone.api.Settings;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
@@ -205,6 +206,12 @@ public class SettingsUtil {
         Class intendedType = setting.getValueClass();
         ISettingParser ioMethod = Parser.getParser(setting.getType());
         Object parsed = ioMethod.parse(setting.getType(), settingValue);
+        if (setting == settings.ignoreServerOreData && parsed instanceof Boolean bool && bool) {
+            IBaritone primary = BaritoneAPI.getProvider().getPrimaryBaritone();
+            if (primary == null || !primary.getSeedPathing().hasSeed()) {
+                throw new IllegalStateException("Cannot enable ignoreServerOreData without a configured seed");
+            }
+        }
         if (!intendedType.isInstance(parsed)) {
             throw new IllegalStateException(ioMethod + " parser returned incorrect type, expected " + intendedType + " got " + parsed + " which is " + parsed.getClass());
         }

--- a/src/main/java/baritone/command/defaults/SetCommand.java
+++ b/src/main/java/baritone/command/defaults/SetCommand.java
@@ -162,6 +162,10 @@ public class SetCommand extends Command {
                 }
                 //noinspection unchecked
                 Settings.Setting<Boolean> asBoolSetting = (Settings.Setting<Boolean>) setting;
+                if (!asBoolSetting.value && setting == Baritone.settings().ignoreServerOreData
+                        && !baritone.getSeedPathing().hasSeed()) {
+                    throw new CommandInvalidStateException("Cannot enable ignoreServerOreData without a configured seed");
+                }
                 asBoolSetting.value ^= true;
                 logDirect(String.format(
                         "Toggled setting %s to %s",

--- a/src/main/java/baritone/pathing/seed/SeedPredictionService.java
+++ b/src/main/java/baritone/pathing/seed/SeedPredictionService.java
@@ -25,6 +25,7 @@ import baritone.pathing.seed.pregen.SectionStore;
 import baritone.pathing.movement.CalculationContext;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.pathing.Favoring;
+import baritone.pathing.seed.ore.PredictedOreTracker;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -77,6 +78,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
     private volatile SectionStore sectionStore;
     private volatile SeedOreMode oreMode;
     private volatile int pregenRadius;
+    private final PredictedOreTracker oreTracker = new PredictedOreTracker();
 
     public SeedPredictionService(Baritone baritone) {
         this.baritone = baritone;
@@ -90,7 +92,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         this.enabled = settings.seedBasedPrediction.value && configuredSeed != null;
         this.oreMode = settings.seedPredictionOreMode.value;
         this.pregenRadius = clampRadius(settings.seedPredictionPregenRadius.value);
-        SectionPregenQueue.init(pregenExecutor, null);
+        SectionPregenQueue.init(pregenExecutor, null, null);
     }
 
     @Override
@@ -112,6 +114,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         settings.seedPredictionSeedConfigured.value = true;
         summaries.clearAll();
         cache.set(null);
+        oreTracker.clearAll();
         if (settings.seedBasedPrediction.value) {
             this.enabled = true;
         }
@@ -127,6 +130,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         cache.set(null);
         enabled = false;
         settings.seedBasedPrediction.value = false;
+        oreTracker.clearAll();
         resetPregen();
     }
 
@@ -161,7 +165,7 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         int clamped = clampRadius(radius);
         this.pregenRadius = clamped;
         Baritone.settings().seedPredictionPregenRadius.value = clamped;
-        SectionPregenQueue.init(pregenExecutor, sectionStore);
+        SectionPregenQueue.init(pregenExecutor, sectionStore, generatorContext != null ? this::handleGeneratedSection : null);
     }
 
     @Override
@@ -173,7 +177,8 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
     public void setGenerationMode(SeedOreMode mode) {
         this.oreMode = mode != null ? mode : SeedOreMode.TERRAIN_ONLY;
         Baritone.settings().seedPredictionOreMode.value = this.oreMode;
-        SectionPregenQueue.init(pregenExecutor, sectionStore);
+        oreTracker.clearAll();
+        SectionPregenQueue.init(pregenExecutor, sectionStore, generatorContext != null ? this::handleGeneratedSection : null);
     }
 
     public void applySeedFavoring(BetterBlockPos start, Goal goal, Favoring favoring, CalculationContext context, IPath previous) {
@@ -274,7 +279,8 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
         generatorContext = new GeneratorContext(seed, registries, holder, randomState,
                 level.dimensionTypeRegistration(), level.dimension(), saveRoot);
         sectionStore = new SectionStore(saveRoot);
-        SectionPregenQueue.init(pregenExecutor, sectionStore);
+        oreTracker.clear(level.dimension());
+        SectionPregenQueue.init(pregenExecutor, sectionStore, this::handleGeneratedSection);
     }
 
     private Path resolveSaveRoot(ClientLevel level) {
@@ -291,9 +297,13 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
     }
 
     private void resetPregen() {
+        GeneratorContext previous = generatorContext;
+        if (previous != null) {
+            oreTracker.clear(previous.dimensionKey());
+        }
         generatorContext = null;
         sectionStore = null;
-        SectionPregenQueue.init(pregenExecutor, null);
+        SectionPregenQueue.init(pregenExecutor, null, null);
     }
 
     private int clampRadius(int radius) {
@@ -356,6 +366,52 @@ public final class SeedPredictionService implements ISeedPathing, AbstractGameEv
                 favoring.multiply(BetterBlockPos.longHash(blockX, y, blockZ), multiplier);
             });
         }
+    }
+
+    private void handleGeneratedSection(baritone.pathing.seed.pregen.SectionBlob blob) {
+        GeneratorContext context = generatorContext;
+        if (context == null) {
+            return;
+        }
+        if (oreMode != SeedOreMode.TERRAIN_PLUS_EXACT_ORES) {
+            return;
+        }
+        oreTracker.ingest(context.dimensionKey(), blob);
+    }
+
+    public List<BlockPos> predictedOreTargets(Level level, baritone.api.utils.BlockOptionalMetaLookup filter, BlockPos origin, int max) {
+        if (!isPredictionEnabled() || level == null) {
+            return Collections.emptyList();
+        }
+        return oreTracker.query(level.dimension(), filter, origin, max);
+    }
+
+    public void markVeinMining(Level level, BlockPos pos) {
+        if (!isPredictionEnabled() || level == null || pos == null) {
+            return;
+        }
+        oreTracker.markVeinMining(level.dimension(), pos);
+    }
+
+    public void markVeinMined(Level level, BlockPos pos) {
+        if (!isPredictionEnabled() || level == null || pos == null) {
+            return;
+        }
+        oreTracker.markVeinMined(level.dimension(), pos);
+    }
+
+    public void markVeinAvailable(Level level, BlockPos pos) {
+        if (!isPredictionEnabled() || level == null || pos == null) {
+            return;
+        }
+        oreTracker.markVeinAvailable(level.dimension(), pos);
+    }
+
+    public BlockState predictedBlockState(Level level, BlockPos pos, BlockState fallback) {
+        if (!isPredictionEnabled() || level == null || pos == null) {
+            return fallback;
+        }
+        return oreTracker.predictedState(level.dimension(), pos, fallback);
     }
 
     private SurfaceMetrics analyzeChunk(Level world, LevelChunk chunk) {

--- a/src/main/java/baritone/pathing/seed/ore/PredictedOreTracker.java
+++ b/src/main/java/baritone/pathing/seed/ore/PredictedOreTracker.java
@@ -1,0 +1,370 @@
+package baritone.pathing.seed.ore;
+
+import baritone.api.utils.BlockOptionalMeta;
+import baritone.api.utils.BlockOptionalMetaLookup;
+import baritone.pathing.seed.pregen.SectionBlob;
+import baritone.pathing.seed.pregen.SectionGenerator;
+import baritone.pathing.seed.pregen.SectionUtil;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Tracks predicted ore positions generated from seed pre-generation and maintains vein status information so Baritone can
+ * avoid revisiting mined veins.
+ */
+public final class PredictedOreTracker {
+
+    private final Map<ResourceKey<Level>, DimensionStore> stores = new ConcurrentHashMap<>();
+    private final Map<ResourceKey<Level>, Map<Long, VeinStatus>> statusMemory = new ConcurrentHashMap<>();
+
+    public void ingest(ResourceKey<Level> dimension, SectionBlob blob) {
+        if (dimension == null || blob == null) {
+            return;
+        }
+        stores.computeIfAbsent(dimension, key -> new DimensionStore(dimension)).ingest(blob);
+    }
+
+    public List<BlockPos> query(ResourceKey<Level> dimension, BlockOptionalMetaLookup filter, BlockPos origin, int max) {
+        DimensionStore store = stores.get(dimension);
+        if (store == null || filter == null) {
+            return Collections.emptyList();
+        }
+        Set<Block> allowed = filter.blocks().stream().map(BlockOptionalMeta::getBlock).collect(Collectors.toSet());
+        if (allowed.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return store.query(allowed, origin, max);
+    }
+
+    public void markVeinMining(ResourceKey<Level> dimension, BlockPos pos) {
+        if (dimension == null || pos == null) {
+            return;
+        }
+        DimensionStore store = stores.get(dimension);
+        if (store != null) {
+            store.markVeinMining(pos.asLong());
+        }
+    }
+
+    public void markVeinMined(ResourceKey<Level> dimension, BlockPos pos) {
+        if (dimension == null || pos == null) {
+            return;
+        }
+        DimensionStore store = stores.get(dimension);
+        if (store != null) {
+            store.markVeinMined(pos.asLong());
+        }
+    }
+
+    public void markVeinAvailable(ResourceKey<Level> dimension, BlockPos pos) {
+        if (dimension == null || pos == null) {
+            return;
+        }
+        DimensionStore store = stores.get(dimension);
+        if (store != null) {
+            store.markVeinAvailable(pos.asLong());
+        }
+    }
+
+    public BlockState predictedState(ResourceKey<Level> dimension, BlockPos pos, BlockState fallback) {
+        DimensionStore store = stores.get(dimension);
+        if (store == null || pos == null) {
+            return fallback;
+        }
+        return store.predictedState(pos.asLong(), fallback);
+    }
+
+    public void clear(ResourceKey<Level> dimension) {
+        if (dimension == null) {
+            return;
+        }
+        stores.remove(dimension);
+        statusMemory.remove(dimension);
+    }
+
+    public void clearAll() {
+        stores.clear();
+        statusMemory.clear();
+    }
+
+    private VeinStatus rememberedStatus(ResourceKey<Level> dimension, long pos) {
+        Map<Long, VeinStatus> status = statusMemory.get(dimension);
+        if (status == null) {
+            return null;
+        }
+        return status.get(pos);
+    }
+
+    private void rememberStatus(ResourceKey<Level> dimension, long pos, VeinStatus status) {
+        statusMemory.computeIfAbsent(dimension, key -> new ConcurrentHashMap<>()).put(pos, status);
+    }
+
+    private static Block mapCategory(byte category) {
+        return switch (category) {
+            case SectionGenerator.O_COAL -> Blocks.COAL_ORE;
+            case SectionGenerator.O_IRON -> Blocks.IRON_ORE;
+            case SectionGenerator.O_COPPER -> Blocks.COPPER_ORE;
+            case SectionGenerator.O_GOLD -> Blocks.GOLD_ORE;
+            case SectionGenerator.O_LAPIS -> Blocks.LAPIS_ORE;
+            case SectionGenerator.O_DIAMOND -> Blocks.DIAMOND_ORE;
+            case SectionGenerator.O_REDSTONE -> Blocks.REDSTONE_ORE;
+            case SectionGenerator.O_EMERALD -> Blocks.EMERALD_ORE;
+            case SectionGenerator.O_DEEPSLATE_COAL -> Blocks.DEEPSLATE_COAL_ORE;
+            case SectionGenerator.O_DEEPSLATE_IRON -> Blocks.DEEPSLATE_IRON_ORE;
+            case SectionGenerator.O_DEEPSLATE_COPPER -> Blocks.DEEPSLATE_COPPER_ORE;
+            case SectionGenerator.O_DEEPSLATE_GOLD -> Blocks.DEEPSLATE_GOLD_ORE;
+            case SectionGenerator.O_DEEPSLATE_LAPIS -> Blocks.DEEPSLATE_LAPIS_ORE;
+            case SectionGenerator.O_DEEPSLATE_DIAMOND -> Blocks.DEEPSLATE_DIAMOND_ORE;
+            case SectionGenerator.O_DEEPSLATE_REDSTONE -> Blocks.DEEPSLATE_REDSTONE_ORE;
+            case SectionGenerator.O_DEEPSLATE_EMERALD -> Blocks.DEEPSLATE_EMERALD_ORE;
+            default -> null;
+        };
+    }
+
+    private enum VeinStatus {
+        UNMINED,
+        MINING,
+        MINED
+    }
+
+    private final class DimensionStore {
+
+        private final Map<Long, PredictedVein> blockIndex = new ConcurrentHashMap<>();
+        private final Map<Long, LongOpenHashSet> sectionIndex = new ConcurrentHashMap<>();
+        private final Set<PredictedVein> veins = ConcurrentHashMap.newKeySet();
+        private final ResourceKey<Level> dimension;
+
+        private DimensionStore(ResourceKey<Level> dimension) {
+            this.dimension = dimension;
+        }
+
+        private synchronized void ingest(SectionBlob blob) {
+            long sectionKey = SectionUtil.key(blob.chunkX(), blob.sectionY(), blob.chunkZ());
+            LongOpenHashSet previous = sectionIndex.remove(sectionKey);
+            if (previous != null) {
+                LongIterator iterator = previous.iterator();
+                while (iterator.hasNext()) {
+                    long pos = iterator.nextLong();
+                    PredictedVein vein = blockIndex.remove(pos);
+                    if (vein != null) {
+                        vein.positions.remove(pos);
+                        if (vein.positions.isEmpty()) {
+                            veins.remove(vein);
+                        }
+                    }
+                }
+            }
+
+            byte[] categories = decode(blob);
+            LongOpenHashSet positions = new LongOpenHashSet();
+            int index = 0;
+            int baseX = blob.chunkX() << 4;
+            int baseY = blob.sectionY() << 4;
+            int baseZ = blob.chunkZ() << 4;
+            for (int y = 0; y < 16; y++) {
+                for (int z = 0; z < 16; z++) {
+                    for (int x = 0; x < 16; x++, index++) {
+                        Block block = mapCategory(categories[index]);
+                        if (block == null) {
+                            continue;
+                        }
+                        long pos = BlockPos.asLong(baseX + x, baseY + y, baseZ + z);
+                        addBlock(pos, block);
+                        positions.add(pos);
+                    }
+                }
+            }
+            sectionIndex.put(sectionKey, positions);
+        }
+
+        private synchronized List<BlockPos> query(Set<Block> allowed, BlockPos origin, int max) {
+            if (veins.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<BlockPos> results = new ArrayList<>();
+            Comparator<BlockPos> sorter = origin == null
+                    ? Comparator.comparingDouble(BlockPos::getY)
+                    : Comparator.comparingDouble(pos -> pos.distSqr(origin));
+            for (PredictedVein vein : veins) {
+                if (!allowed.contains(vein.block)) {
+                    continue;
+                }
+                if (vein.status == VeinStatus.MINED || vein.status == VeinStatus.MINING || vein.positions.isEmpty()) {
+                    continue;
+                }
+                LongIterator iterator = vein.positions.iterator();
+                while (iterator.hasNext()) {
+                    results.add(BlockPos.of(iterator.nextLong()));
+                    if (max > 0 && results.size() >= max) {
+                        break;
+                    }
+                }
+                if (max > 0 && results.size() >= max) {
+                    break;
+                }
+            }
+            results.sort(sorter);
+            if (max > 0 && results.size() > max) {
+                return new ArrayList<>(results.subList(0, max));
+            }
+            return results;
+        }
+
+        private synchronized void markVeinMining(long pos) {
+            PredictedVein vein = blockIndex.get(pos);
+            if (vein != null && vein.status == VeinStatus.UNMINED) {
+                vein.status = VeinStatus.MINING;
+            }
+        }
+
+        private synchronized void markVeinMined(long pos) {
+            PredictedVein vein = blockIndex.get(pos);
+            if (vein == null) {
+                return;
+            }
+            vein.status = VeinStatus.MINED;
+            LongIterator iterator = vein.positions.iterator();
+            while (iterator.hasNext()) {
+                long value = iterator.nextLong();
+                rememberStatus(dimension, value, VeinStatus.MINED);
+            }
+        }
+
+        private synchronized void markVeinAvailable(long pos) {
+            PredictedVein vein = blockIndex.get(pos);
+            if (vein == null || vein.status == VeinStatus.MINED) {
+                return;
+            }
+            vein.status = VeinStatus.UNMINED;
+        }
+
+        private synchronized BlockState predictedState(long pos, BlockState fallback) {
+            PredictedVein vein = blockIndex.get(pos);
+            if (vein == null || vein.positions.isEmpty() || vein.status == VeinStatus.MINED) {
+                return fallback;
+            }
+            return vein.block.defaultBlockState();
+        }
+
+        private void addBlock(long pos, Block block) {
+            PredictedVein target = null;
+            List<PredictedVein> toMerge = null;
+            for (long neighbor : neighbors(pos)) {
+                PredictedVein neighborVein = blockIndex.get(neighbor);
+                if (neighborVein != null && neighborVein.block == block) {
+                    if (target == null) {
+                        target = neighborVein;
+                    } else if (target != neighborVein) {
+                        if (toMerge == null) {
+                            toMerge = new ArrayList<>();
+                        }
+                        if (!toMerge.contains(neighborVein)) {
+                            toMerge.add(neighborVein);
+                        }
+                    }
+                }
+            }
+            if (target == null) {
+                target = new PredictedVein(block);
+                veins.add(target);
+            }
+            target.positions.add(pos);
+            blockIndex.put(pos, target);
+            if (toMerge != null) {
+                for (PredictedVein other : toMerge) {
+                    mergeVeins(target, other);
+                }
+            }
+            VeinStatus remembered = rememberedStatus(dimension, pos);
+            if (remembered == VeinStatus.MINED) {
+                target.status = VeinStatus.MINED;
+            }
+        }
+
+        private void mergeVeins(PredictedVein target, PredictedVein other) {
+            if (target == other) {
+                return;
+            }
+            target.status = mergeStatus(target.status, other.status);
+            LongIterator iterator = other.positions.iterator();
+            while (iterator.hasNext()) {
+                long value = iterator.nextLong();
+                target.positions.add(value);
+                blockIndex.put(value, target);
+            }
+            veins.remove(other);
+        }
+
+        private List<Long> neighbors(long pos) {
+            List<Long> neighborList = new ArrayList<>(6);
+            BlockPos base = BlockPos.of(pos);
+            neighborList.add(base.above().asLong());
+            neighborList.add(base.below().asLong());
+            neighborList.add(base.north().asLong());
+            neighborList.add(base.south().asLong());
+            neighborList.add(base.east().asLong());
+            neighborList.add(base.west().asLong());
+            return neighborList;
+        }
+
+        private VeinStatus mergeStatus(VeinStatus first, VeinStatus second) {
+            if (first == VeinStatus.MINED || second == VeinStatus.MINED) {
+                return VeinStatus.MINED;
+            }
+            if (first == VeinStatus.MINING || second == VeinStatus.MINING) {
+                return VeinStatus.MINING;
+            }
+            return VeinStatus.UNMINED;
+        }
+
+        private byte[] decode(SectionBlob blob) {
+            byte[] rle = blob.rleData();
+            byte[] values = new byte[16 * 16 * 16];
+            int index = 0;
+            int offset = 0;
+            for (int run = 0; run < blob.runCount() && index < values.length; run++) {
+                int value = rle[offset++] & 0xFF;
+                int length = 0;
+                int shift = 0;
+                while (true) {
+                    int b = rle[offset++] & 0xFF;
+                    length |= (b & 0x7F) << shift;
+                    if ((b & 0x80) == 0) {
+                        break;
+                    }
+                    shift += 7;
+                }
+                for (int i = 0; i < length && index < values.length; i++) {
+                    values[index++] = (byte) value;
+                }
+            }
+            return values;
+        }
+    }
+
+    private static final class PredictedVein {
+        private final Block block;
+        private final LongOpenHashSet positions = new LongOpenHashSet();
+        private VeinStatus status = VeinStatus.UNMINED;
+
+        private PredictedVein(Block block) {
+            this.block = Objects.requireNonNull(block, "block");
+        }
+    }
+}

--- a/src/main/java/baritone/pathing/seed/pregen/SectionPregenQueue.java
+++ b/src/main/java/baritone/pathing/seed/pregen/SectionPregenQueue.java
@@ -5,24 +5,27 @@ import baritone.api.pathing.seed.SeedOreMode;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 public final class SectionPregenQueue {
 
     private static ExecutorService executor;
     private static SectionStore store;
+    private static Consumer<SectionBlob> listener;
     private static final Set<Long> seen = ConcurrentHashMap.newKeySet();
 
     private SectionPregenQueue() {
     }
 
-    public static void init(ExecutorService service, SectionStore sectionStore) {
+    public static void init(ExecutorService service, SectionStore sectionStore, Consumer<SectionBlob> sectionListener) {
         executor = service;
         store = sectionStore;
+        listener = sectionListener;
         seen.clear();
     }
 
     public static void queueAround(GeneratorContext context, int playerChunkX, int playerChunkZ, int radius, SeedOreMode mode) {
-        if (executor == null || store == null) {
+        if (executor == null) {
             return;
         }
         int minChunkX = playerChunkX - radius;
@@ -43,7 +46,12 @@ public final class SectionPregenQueue {
                     final int fz = chunkZ;
                     executor.submit(() -> {
                         SectionBlob blob = SectionGenerator.generate(context, fx, fy, fz, mode);
-                        store.write(blob);
+                        if (store != null) {
+                            store.write(blob);
+                        }
+                        if (listener != null) {
+                            listener.accept(blob);
+                        }
                     });
                 }
             }

--- a/src/main/java/baritone/process/MineProcess.java
+++ b/src/main/java/baritone/process/MineProcess.java
@@ -40,6 +40,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.Level;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -89,7 +90,12 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
                 if (Baritone.settings().notificationOnMineFail.value) {
                     logNotification("Unable to find any path to " + filter + ", blacklisting presumably unreachable closest instance...", true);
                 }
-                knownOreLocations.stream().min(Comparator.comparingDouble(ctx.playerFeet()::distSqr)).ifPresent(blacklist::add);
+                knownOreLocations.stream().min(Comparator.comparingDouble(ctx.playerFeet()::distSqr)).ifPresent(pos -> {
+                    blacklist.add(pos);
+                    if (Baritone.settings().ignoreServerOreData.value) {
+                        baritone.getSeedPrediction().markVeinMined(ctx.world(), pos);
+                    }
+                });
                 knownOreLocations.removeIf(blacklist::contains);
             } else {
                 logDirect("Unable to find any path to " + filter + ", canceling mine");
@@ -186,6 +192,9 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
             List<BlockPos> locs2 = prune(context, new ArrayList<>(locs), filter, Baritone.settings().mineMaxOreLocationsCount.value, blacklist, droppedItemsScan());
             // can't reassign locs, gotta make a new var locs2, because we use it in a lambda right here, and variables you use in a lambda must be effectively final
             Goal goal = new GoalComposite(locs2.stream().map(loc -> coalesce(loc, locs2, context)).toArray(Goal[]::new));
+            if (Baritone.settings().ignoreServerOreData.value && !locs2.isEmpty()) {
+                baritone.getSeedPrediction().markVeinMining(context.world, locs2.get(0));
+            }
             knownOreLocations = locs2;
             return new PathingCommand(goal, legit ? PathingCommandType.FORCE_REVALIDATE_GOAL_AND_PATH : PathingCommandType.REVALIDATE_GOAL_AND_PATH);
         }
@@ -230,6 +239,12 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
         }
         if (Baritone.settings().legitMine.value) {
             return;
+        }
+        if (Baritone.settings().ignoreServerOreData.value) {
+            Level world = context.world;
+            for (BlockPos pos : already) {
+                baritone.getSeedPrediction().markVeinAvailable(world, pos);
+            }
         }
         List<BlockPos> dropped = droppedItemsScan();
         List<BlockPos> locs = searchWorld(context, filter, Baritone.settings().mineMaxOreLocationsCount.value, already, blacklist, dropped);
@@ -389,6 +404,16 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
             )); // maxSearchRadius is NOT sq
         }
 
+        if (Baritone.settings().ignoreServerOreData.value && ctx.getBaritone() instanceof Baritone brt) {
+            List<BlockPos> predicted = brt.getSeedPrediction().predictedOreTargets(
+                    ctx.world,
+                    filter,
+                    ctx.getBaritone().getPlayerContext().playerFeet(),
+                    max
+            );
+            locs.addAll(predicted);
+        }
+
         locs.addAll(alreadyKnown);
 
         return prune(ctx, locs, filter, max, blacklist, dropped);
@@ -464,6 +489,20 @@ public final class MineProcess extends BaritoneProcessHelper implements IMinePro
 
         if (locs.size() > max) {
             return locs.subList(0, max);
+        }
+        if (Baritone.settings().ignoreServerOreData.value && ctx.getBaritone() instanceof Baritone brt) {
+            Iterator<BlockPos> iterator = locs.iterator();
+            while (iterator.hasNext()) {
+                BlockPos pos = iterator.next();
+                if (!ctx.bsi.worldContainsLoadedChunk(pos.getX(), pos.getZ())) {
+                    continue;
+                }
+                BlockState actual = ctx.bsi.getActualBlockState(pos.getX(), pos.getY(), pos.getZ());
+                if (!filter.has(actual)) {
+                    iterator.remove();
+                    brt.getSeedPrediction().markVeinMined(ctx.world, pos);
+                }
+            }
         }
         return locs;
     }

--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -18,6 +18,8 @@
 package baritone.utils;
 
 import baritone.Baritone;
+import baritone.api.BaritoneAPI;
+import baritone.api.IBaritone;
 import baritone.api.utils.IPlayerContext;
 import baritone.cache.CachedRegion;
 import baritone.cache.WorldData;
@@ -33,6 +35,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
+import net.minecraft.world.level.dimension.DimensionType;
 
 /**
  * Wraps get for chuck caching capability
@@ -94,32 +97,41 @@ public class BlockStateInterface {
         return get0(pos.getX(), pos.getY(), pos.getZ());
     }
 
+    public BlockState getActualBlockState(BlockPos pos) {
+        return getActualBlockState(pos.getX(), pos.getY(), pos.getZ());
+    }
+
     public BlockState get0(int x, int y, int z) { // Mickey resigned
-        y -= world.dimensionType().minY();
-        // Invalid vertical position
-        if (y < 0 || y >= world.dimensionType().height()) {
+        return getInternal(x, y, z, true);
+    }
+
+    public BlockState getActualBlockState(int x, int y, int z) {
+        return getInternal(x, y, z, false);
+    }
+
+    private BlockState getInternal(int x, int y, int z, boolean allowPrediction) {
+        DimensionType dimensionType = world.dimensionType();
+        int minY = dimensionType.minY();
+        int height = dimensionType.height();
+        int worldY = y;
+        int localY = worldY - minY;
+        if (localY < 0 || localY >= height) {
             return AIR;
         }
 
         if (useTheRealWorld) {
             LevelChunk cached = prev;
-            // there's great cache locality in block state lookups
-            // generally it's within each movement
-            // if it's the same chunk as last time
-            // we can just skip the mc.world.getChunk lookup
-            // which is a Long2ObjectOpenHashMap.get
-            // see issue #113
             if (cached != null && cached.getPos().x == x >> 4 && cached.getPos().z == z >> 4) {
-                return getFromChunk(cached, x, y, z);
+                BlockState state = getFromChunk(cached, x, localY, z);
+                return allowPrediction ? maybeOverrideWithPrediction(state, x, worldY, z) : state;
             }
             LevelChunk chunk = provider.getChunk(x >> 4, z >> 4, ChunkStatus.FULL, false);
             if (chunk != null && !chunk.isEmpty()) {
                 prev = chunk;
-                return getFromChunk(chunk, x, y, z);
+                BlockState state = getFromChunk(chunk, x, localY, z);
+                return allowPrediction ? maybeOverrideWithPrediction(state, x, worldY, z) : state;
             }
         }
-        // same idea here, skip the Long2ObjectOpenHashMap.get if at all possible
-        // except here, it's 512x512 tiles instead of 16x16, so even better repetition
         CachedRegion cached = prevCached;
         if (cached == null || cached.getX() != x >> 9 || cached.getZ() != z >> 9) {
             if (worldData == null) {
@@ -132,11 +144,11 @@ public class BlockStateInterface {
             prevCached = region;
             cached = region;
         }
-        BlockState type = cached.getBlock(x & 511, y + world.dimensionType().minY(), z & 511);
+        BlockState type = cached.getBlock(x & 511, worldY, z & 511);
         if (type == null) {
-            return AIR;
+            type = AIR;
         }
-        return type;
+        return allowPrediction ? maybeOverrideWithPrediction(type, x, worldY, z) : type;
     }
 
     public boolean isLoaded(int x, int z) {
@@ -171,5 +183,16 @@ public class BlockStateInterface {
             return AIR;
         }
         return section.getBlockState(x & 15, y & 15, z & 15);
+    }
+
+    private BlockState maybeOverrideWithPrediction(BlockState original, int x, int y, int z) {
+        if (!Baritone.settings().ignoreServerOreData.value) {
+            return original;
+        }
+        IBaritone primary = BaritoneAPI.getProvider().getPrimaryBaritone();
+        if (!(primary instanceof Baritone baritone)) {
+            return original;
+        }
+        return baritone.getSeedPrediction().predictedBlockState(world, new BlockPos(x, y, z), original);
     }
 }


### PR DESCRIPTION
## Summary
- add an ignoreServerOreData setting that can only be enabled when a prediction seed is configured
- track locally generated ore veins and hook them into seed pre-generation and mining logic
- have mining and block queries prefer predicted ore data while recording mined or abandoned veins to avoid repeats

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_b_68d951fd52e0832f8c196464f12761ab