### PR TITLE
Add per-server settings profiles with global overrides

### DIFF
--- a/src/api/java/baritone/api/utils/SettingsUtil.java
+++ b/src/api/java/baritone/api/utils/SettingsUtil.java
@@ -42,7 +42,9 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -75,6 +77,35 @@ public class SettingsUtil {
     }
 
     public static void readAndApply(Settings settings, String settingsName) {
+        Map<String, String> rawValues = readRaw(settingsName, SETTINGS_DEFAULT_NAME.equals(settingsName));
+        rawValues.forEach((settingName, settingValue) -> {
+            try {
+                parseAndApply(settings, settingName, settingValue);
+            } catch (Exception ex) {
+                Helper.HELPER.logDirect("Unable to parse setting " + settingName + " from " + settingsName);
+                ex.printStackTrace();
+            }
+        });
+    }
+
+    public static synchronized void save(Settings settings) {
+        Map<String, String> values = new HashMap<>();
+        for (Settings.Setting setting : modifiedSettings(settings)) {
+            values.put(setting.getName().toLowerCase(Locale.US), settingValueToString(setting));
+        }
+        writeRaw(SETTINGS_DEFAULT_NAME, values);
+    }
+
+    private static Path settingsByName(String name) {
+        return Minecraft.getInstance().gameDirectory.toPath().resolve("baritone").resolve(name);
+    }
+
+    public static Map<String, String> readRaw(String settingsName) {
+        return readRaw(settingsName, true);
+    }
+
+    public static Map<String, String> readRaw(String settingsName, boolean logMissing) {
+        Map<String, String> values = new HashMap<>();
         try {
             forEachLine(settingsByName(settingsName), line -> {
                 Matcher matcher = SETTING_PATTERN.matcher(line);
@@ -83,40 +114,54 @@ public class SettingsUtil {
                     return;
                 }
 
-                String settingName = matcher.group("setting").toLowerCase();
+                String settingName = matcher.group("setting").toLowerCase(Locale.US);
                 String settingValue = matcher.group("value");
-                // TODO remove soonish
                 if ("allowjumpat256".equals(settingName)) {
                     settingName = "allowjumpatbuildlimit";
                 }
-                try {
-                    parseAndApply(settings, settingName, settingValue);
-                } catch (Exception ex) {
-                    Helper.HELPER.logDirect("Unable to parse line " + line);
-                    ex.printStackTrace();
-                }
+                values.put(settingName, settingValue);
             });
         } catch (NoSuchFileException ignored) {
-            Helper.HELPER.logDirect("Baritone settings file not found, resetting.");
+            if (logMissing) {
+                Helper.HELPER.logDirect("Baritone settings file not found, resetting.");
+            }
         } catch (Exception ex) {
-            Helper.HELPER.logDirect("Exception while reading Baritone settings, some settings may be reset to default values!");
+            Helper.HELPER.logDirect("Exception while reading Baritone settings from " + settingsName + ", some settings may be reset to default values!");
             ex.printStackTrace();
         }
+        return values;
     }
 
-    public static synchronized void save(Settings settings) {
-        try (BufferedWriter out = Files.newBufferedWriter(settingsByName(SETTINGS_DEFAULT_NAME))) {
-            for (Settings.Setting setting : modifiedSettings(settings)) {
-                out.write(settingToString(setting) + "\n");
+    public static synchronized void writeRaw(String settingsName, Map<String, String> values) {
+        Path file = settingsByName(settingsName);
+        try {
+            Path parent = file.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            try (BufferedWriter out = Files.newBufferedWriter(file)) {
+                values.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .forEach(entry -> {
+                            try {
+                                out.write(entry.getKey() + " " + entry.getValue());
+                                out.newLine();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+            }
+        } catch (RuntimeException runtime) {
+            if (runtime.getCause() instanceof IOException io) {
+                Helper.HELPER.logDirect("Exception thrown while saving Baritone settings!");
+                io.printStackTrace();
+            } else {
+                throw runtime;
             }
         } catch (Exception ex) {
             Helper.HELPER.logDirect("Exception thrown while saving Baritone settings!");
             ex.printStackTrace();
         }
-    }
-
-    private static Path settingsByName(String name) {
-        return Minecraft.getInstance().gameDirectory.toPath().resolve("baritone").resolve(name);
     }
 
     public static List<Settings.Setting> modifiedSettings(Settings settings) {

--- a/src/main/java/baritone/Baritone.java
+++ b/src/main/java/baritone/Baritone.java
@@ -31,6 +31,7 @@ import baritone.cache.WorldProvider;
 import baritone.command.manager.CommandManager;
 import baritone.event.GameEventHandler;
 import baritone.process.*;
+import baritone.settings.SettingsProfileManager;
 import baritone.selection.SelectionManager;
 import baritone.utils.BlockStateInterface;
 import baritone.utils.GuiClick;
@@ -90,6 +91,7 @@ public class Baritone implements IBaritone {
     private final PathingControlManager pathingControlManager;
     private final SelectionManager selectionManager;
     private final CommandManager commandManager;
+    private final SettingsProfileManager settingsProfileManager;
 
     private final SeedPredictionService seedPrediction;
 
@@ -142,8 +144,10 @@ public class Baritone implements IBaritone {
         this.worldProvider = new WorldProvider(this);
         this.selectionManager = new SelectionManager(this);
         this.commandManager = new CommandManager(this);
+        this.settingsProfileManager = new SettingsProfileManager(this);
         this.seedPrediction = new SeedPredictionService(this);
         this.gameEventHandler.registerEventListener(this.seedPrediction);
+        this.gameEventHandler.registerEventListener(this.settingsProfileManager);
     }
 
     public void registerBehavior(IBehavior behavior) {
@@ -263,6 +267,10 @@ public class Baritone implements IBaritone {
     @Override
     public CommandManager getCommandManager() {
         return this.commandManager;
+    }
+
+    public SettingsProfileManager getSettingsProfileManager() {
+        return this.settingsProfileManager;
     }
 
     @Override

--- a/src/main/java/baritone/command/defaults/SetCommand.java
+++ b/src/main/java/baritone/command/defaults/SetCommand.java
@@ -30,6 +30,7 @@ import baritone.api.command.exception.CommandInvalidTypeException;
 import baritone.api.command.helpers.Paginator;
 import baritone.api.command.helpers.TabCompleteHelper;
 import baritone.api.utils.SettingsUtil;
+import baritone.settings.SettingsProfileManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.ClickEvent;
@@ -54,22 +55,45 @@ public class SetCommand extends Command {
 
     @Override
     public void execute(String label, IArgConsumer args) throws CommandException {
-        String arg = args.hasAny() ? args.getString().toLowerCase(Locale.US) : "list";
-        if (Arrays.asList("s", "save").contains(arg)) {
-            SettingsUtil.save(Baritone.settings());
-            logDirect("Settings saved");
+        Baritone impl = (Baritone) this.baritone;
+        SettingsProfileManager profiles = impl.getSettingsProfileManager();
+
+        boolean globalContext = false;
+        String arg = args.hasAny() ? args.getString() : "list";
+        if (arg.equalsIgnoreCase("global")) {
+            globalContext = true;
+            arg = args.hasAny() ? args.getString() : "list";
+        }
+
+        String lowerArg = arg.toLowerCase(Locale.US);
+        if (Arrays.asList("s", "save").contains(lowerArg)) {
+            if (!globalContext && args.hasAny()) {
+                String next = args.peekString();
+                if ("global".equalsIgnoreCase(next)) {
+                    args.getString();
+                    globalContext = true;
+                }
+            }
+            if (globalContext) {
+                profiles.saveGlobalOverrides();
+                logDirect("Global settings saved");
+            } else {
+                profiles.saveActiveProfile();
+                logDirect(String.format("Settings saved for %s", profiles.describeActiveProfile()));
+            }
             return;
         }
-        if (Arrays.asList("load", "ld").contains(arg)) {
-            String file = SETTINGS_DEFAULT_NAME;
+        if (Arrays.asList("load", "ld").contains(lowerArg)) {
+            String file = globalContext ? SETTINGS_DEFAULT_NAME : profiles.getActiveProfileFile();
             if (args.hasAny()) {
                 file = args.getString();
             }
-            // reset to defaults
-            SettingsUtil.modifiedSettings(Baritone.settings()).forEach(Settings.Setting::reset);
-            // then load from disk
-            SettingsUtil.readAndApply(Baritone.settings(), file);
-            logDirect("Settings reloaded from " + file);
+            if (globalContext) {
+                profiles.loadOverridesFromFile(file, true);
+            } else {
+                profiles.loadOverridesFromFile(file, false);
+            }
+            logDirect(String.format("Settings reloaded from %s for %s", file, profiles.describeScope(globalContext)));
             return;
         }
         boolean viewModified = Arrays.asList("m", "mod", "modified").contains(arg);
@@ -118,8 +142,8 @@ public class SetCommand extends Command {
             return;
         }
         args.requireMax(1);
-        boolean resetting = arg.equalsIgnoreCase("reset");
-        boolean toggling = arg.equalsIgnoreCase("toggle");
+        boolean resetting = lowerArg.equals("reset");
+        boolean toggling = lowerArg.equals("toggle");
         boolean doingSomething = resetting || toggling;
         if (resetting) {
             if (!args.hasAny()) {
@@ -127,9 +151,10 @@ public class SetCommand extends Command {
                 logDirect("ALL settings will be reset. Use the 'set modified' or 'modified' commands to see what will be reset.");
                 logDirect("Specify a setting name instead of 'all' to only reset one setting");
             } else if (args.peekString().equalsIgnoreCase("all")) {
-                SettingsUtil.modifiedSettings(Baritone.settings()).forEach(Settings.Setting::reset);
-                logDirect("All settings have been reset to their default values");
-                SettingsUtil.save(Baritone.settings());
+                args.getString();
+                profiles.resetAll(globalContext);
+                logDirect(String.format("All settings for %s have been reset to their default values", profiles.describeScope(globalContext)));
+                profiles.saveScope(globalContext);
                 return;
             }
         }
@@ -156,27 +181,29 @@ public class SetCommand extends Command {
         } else {
             String oldValue = settingValueToString(setting);
             if (resetting) {
-                setting.reset();
+                profiles.resetSetting(setting, globalContext);
             } else if (toggling) {
                 if (setting.getValueClass() != Boolean.class) {
                     throw new CommandInvalidTypeException(args.consumed(), "a toggleable setting", "some other setting");
                 }
                 //noinspection unchecked
                 Settings.Setting<Boolean> asBoolSetting = (Settings.Setting<Boolean>) setting;
-                if (!asBoolSetting.value && setting == Baritone.settings().ignoreServerOreData
-                        && !baritone.getSeedPathing().hasSeed()) {
+                boolean newValue = !asBoolSetting.value;
+                if (newValue && setting == Baritone.settings().ignoreServerOreData
+                        && !impl.getSeedPathing().hasSeed()) {
                     throw new CommandInvalidStateException("Cannot enable ignoreServerOreData without a configured seed");
                 }
-                asBoolSetting.value ^= true;
+                profiles.setValue(setting, Boolean.toString(newValue), globalContext);
                 logDirect(String.format(
-                        "Toggled setting %s to %s",
+                        "Toggled setting %s to %s for %s",
                         setting.getName(),
-                        Boolean.toString((Boolean) setting.value)
+                        Boolean.toString((Boolean) setting.value),
+                        profiles.describeScope(globalContext)
                 ));
             } else {
                 String newValue = args.getString();
                 try {
-                    SettingsUtil.parseAndApply(Baritone.settings(), arg, newValue);
+                    profiles.setValue(setting, newValue, globalContext);
                 } catch (Throwable t) {
                     t.printStackTrace();
                     throw new CommandInvalidTypeException(args.consumed(), "a valid value", t);
@@ -184,10 +211,11 @@ public class SetCommand extends Command {
             }
             if (!toggling) {
                 logDirect(String.format(
-                        "Successfully %s %s to %s",
+                        "Successfully %s %s to %s for %s",
                         resetting ? "reset" : "set",
                         setting.getName(),
-                        settingValueToString(setting)
+                        settingValueToString(setting),
+                        profiles.describeScope(globalContext)
                 ));
             }
             MutableComponent oldValueComponent = Component.literal(String.format("Old value: %s", oldValue));
@@ -197,7 +225,11 @@ public class SetCommand extends Command {
                             Component.literal("Click to set the setting back to this value")
                     ))
                     .withClickEvent(new ClickEvent.RunCommand(
-                            FORCE_COMMAND_PREFIX + String.format("set %s %s", setting.getName(), oldValue)
+                            FORCE_COMMAND_PREFIX + String.format(
+                                    globalContext ? "set global %s %s" : "set %s %s",
+                                    setting.getName(),
+                                    oldValue
+                            )
                     )));
             logDirect(oldValueComponent);
             if ((setting.getName().equals("chatControl") && !(Boolean) setting.value && !Baritone.settings().chatControlAnyway.value) ||
@@ -207,51 +239,69 @@ public class SetCommand extends Command {
                 logDirect("Warning: Prefixed commands will no longer work. If you want to revert this change, use chat control (if enabled) or click the old value listed above.", ChatFormatting.RED);
             }
         }
-        SettingsUtil.save(Baritone.settings());
+        profiles.saveScope(globalContext);
     }
 
     @Override
     public Stream<String> tabComplete(String label, IArgConsumer args) throws CommandException {
-        if (args.hasAny()) {
-            String arg = args.getString();
-            if (args.hasExactlyOne() && !Arrays.asList("s", "save").contains(args.peekString().toLowerCase(Locale.US))) {
-                if (arg.equalsIgnoreCase("reset")) {
-                    return new TabCompleteHelper()
-                            .addModifiedSettings()
-                            .prepend("all")
-                            .filterPrefix(args.getString())
-                            .stream();
-                } else if (arg.equalsIgnoreCase("toggle")) {
-                    return new TabCompleteHelper()
-                            .addToggleableSettings()
-                            .filterPrefix(args.getString())
-                            .stream();
-                } else if (Arrays.asList("ld", "load").contains(arg.toLowerCase(Locale.US))) {
-                    // settings always use the directory of the main Minecraft instance
-                    return RelativeFile.tabComplete(args, Minecraft.getInstance().gameDirectory.toPath().resolve("baritone").toFile());
-                }
-                Settings.Setting setting = Baritone.settings().byLowerName.get(arg.toLowerCase(Locale.US));
-                if (setting != null) {
-                    if (setting.getType() == Boolean.class) {
-                        TabCompleteHelper helper = new TabCompleteHelper();
-                        if ((Boolean) setting.value) {
-                            helper.append("true", "false");
-                        } else {
-                            helper.append("false", "true");
-                        }
-                        return helper.filterPrefix(args.getString()).stream();
-                    } else {
-                        return Stream.of(settingValueToString(setting));
-                    }
-                }
-            } else if (!args.hasAny()) {
-                return new TabCompleteHelper()
-                        .addSettings()
-                        .sortAlphabetically()
-                        .prepend("list", "modified", "reset", "toggle", "save", "load")
-                        .filterPrefix(arg)
-                        .stream();
+        if (!args.hasAny()) {
+            return new TabCompleteHelper()
+                    .addSettings()
+                    .sortAlphabetically()
+                    .prepend("list", "modified", "reset", "toggle", "save", "load", "global")
+                    .stream();
+        }
+
+        String first = args.getString();
+        if (first.equalsIgnoreCase("global")) {
+            if (!args.hasAny()) {
+                return tabCompleteAfterPrefix(args, "", false);
             }
+            return tabCompleteAfterPrefix(args, args.getString(), false);
+        }
+
+        return tabCompleteAfterPrefix(args, first, true);
+    }
+
+    private Stream<String> tabCompleteAfterPrefix(IArgConsumer args, String currentArg, boolean includeGlobal) throws CommandException {
+        if (args.hasExactlyOne() && !Arrays.asList("s", "save").contains(args.peekString().toLowerCase(Locale.US))) {
+            if (currentArg.equalsIgnoreCase("reset")) {
+                return new TabCompleteHelper()
+                        .addModifiedSettings()
+                        .prepend("all")
+                        .filterPrefix(args.getString())
+                        .stream();
+            } else if (currentArg.equalsIgnoreCase("toggle")) {
+                return new TabCompleteHelper()
+                        .addToggleableSettings()
+                        .filterPrefix(args.getString())
+                        .stream();
+            } else if (Arrays.asList("ld", "load").contains(currentArg.toLowerCase(Locale.US))) {
+                return RelativeFile.tabComplete(args, Minecraft.getInstance().gameDirectory.toPath().resolve("baritone").toFile());
+            }
+            Settings.Setting setting = Baritone.settings().byLowerName.get(currentArg.toLowerCase(Locale.US));
+            if (setting != null) {
+                if (setting.getType() == Boolean.class) {
+                    TabCompleteHelper helper = new TabCompleteHelper();
+                    if ((Boolean) setting.value) {
+                        helper.append("true", "false");
+                    } else {
+                        helper.append("false", "true");
+                    }
+                    return helper.filterPrefix(args.getString()).stream();
+                } else {
+                    return Stream.of(settingValueToString(setting));
+                }
+            }
+        } else if (!args.hasAny()) {
+            TabCompleteHelper helper = new TabCompleteHelper()
+                    .addSettings()
+                    .sortAlphabetically()
+                    .prepend("list", "modified", "reset", "toggle", "save", "load");
+            if (includeGlobal) {
+                helper.prepend("global");
+            }
+            return helper.filterPrefix(currentArg).stream();
         }
         return Stream.empty();
     }
@@ -271,13 +321,17 @@ public class SetCommand extends Command {
                 "> set list [page] - View all settings",
                 "> set modified [page] - View modified settings",
                 "> set <setting> - View the current value of a setting",
-                "> set <setting> <value> - Set the value of a setting",
-                "> set reset all - Reset ALL SETTINGS to their defaults",
+                "> set <setting> <value> - Set the value of a setting for the current server or world",
+                "> set global <setting> <value> - Set a global default value that applies everywhere",
+                "> set reset all - Reset all settings for the current server or world to their defaults",
+                "> set global reset all - Reset ALL global settings to their defaults",
                 "> set reset <setting> - Reset a setting to its default",
                 "> set toggle <setting> - Toggle a boolean setting",
-                "> set save - Save all settings (this is automatic tho)",
-                "> set load - Load settings from settings.txt",
-                "> set load [filename] - Load settings from another file in your minecraft/baritone"
+                "> set save - Save settings for the current server or world (done automatically)",
+                "> set save global - Save global settings",
+                "> set load - Reload settings for the current server or world",
+                "> set load [filename] - Load settings from another file into the active profile",
+                "> set global load [filename] - Load settings from another file into the global profile"
         );
     }
 }

--- a/src/main/java/baritone/settings/SettingsProfileManager.java
+++ b/src/main/java/baritone/settings/SettingsProfileManager.java
@@ -1,0 +1,264 @@
+/*
+ * This file is part of Baritone.
+ *
+ * Baritone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Baritone is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Baritone.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package baritone.settings;
+
+import baritone.Baritone;
+import baritone.api.Settings;
+import baritone.api.event.events.WorldEvent;
+import baritone.api.event.events.type.EventState;
+import baritone.api.event.listener.AbstractGameEventListener;
+import baritone.api.utils.Helper;
+import baritone.api.utils.SettingsUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Manages the currently active settings profile based on the connected server or singleplayer world.
+ * Global overrides are loaded first and per-server or per-world overrides are layered on top.
+ */
+public class SettingsProfileManager implements AbstractGameEventListener {
+
+    private static final Pattern INVALID_CHARACTERS = Pattern.compile("[^a-zA-Z0-9._-]");
+
+    private final Baritone baritone;
+    private final Settings settings;
+
+    private final Map<String, String> globalOverrides = new HashMap<>();
+    private final Map<String, String> profileOverrides = new HashMap<>();
+
+    private String activeProfileFile = SettingsUtil.SETTINGS_DEFAULT_NAME;
+    private String activeProfileDescription = "global profile";
+
+    public SettingsProfileManager(Baritone baritone) {
+        this.baritone = baritone;
+        this.settings = Baritone.settings();
+        reloadGlobalOverrides();
+        refreshProfileFromEnvironment();
+    }
+
+    @Override
+    public void onWorldEvent(WorldEvent event) {
+        if (event.getState() != EventState.POST) {
+            return;
+        }
+        refreshProfileFromEnvironment();
+    }
+
+    public void refreshProfileFromEnvironment() {
+        ProfileTarget target = computeProfileTarget();
+        boolean changedFile = !Objects.equals(target.file, this.activeProfileFile);
+        boolean changedDescription = !Objects.equals(target.description, this.activeProfileDescription);
+
+        if (changedFile) {
+            this.activeProfileFile = target.file;
+            this.profileOverrides.clear();
+            if (!SettingsUtil.SETTINGS_DEFAULT_NAME.equals(this.activeProfileFile)) {
+                this.profileOverrides.putAll(SettingsUtil.readRaw(this.activeProfileFile, false));
+            }
+            Helper.HELPER.logDirect("Loaded Baritone settings for " + target.description);
+        }
+
+        this.activeProfileDescription = target.description;
+
+        if (changedFile || changedDescription) {
+            refreshSettings();
+        }
+    }
+
+    public void reloadGlobalOverrides() {
+        this.globalOverrides.clear();
+        this.globalOverrides.putAll(SettingsUtil.readRaw(SettingsUtil.SETTINGS_DEFAULT_NAME));
+        refreshSettings();
+    }
+
+    public void reloadActiveProfile() {
+        this.profileOverrides.clear();
+        if (!SettingsUtil.SETTINGS_DEFAULT_NAME.equals(this.activeProfileFile)) {
+            this.profileOverrides.putAll(SettingsUtil.readRaw(this.activeProfileFile, false));
+        }
+        refreshSettings();
+    }
+
+    public void loadOverridesFromFile(String file, boolean global) {
+        Map<String, String> data = SettingsUtil.readRaw(file, global);
+        if (global) {
+            this.globalOverrides.clear();
+            this.globalOverrides.putAll(data);
+        } else {
+            this.profileOverrides.clear();
+            this.profileOverrides.putAll(data);
+        }
+        refreshSettings();
+    }
+
+    public void resetAll(boolean global) {
+        if (global) {
+            this.globalOverrides.clear();
+        } else {
+            this.profileOverrides.clear();
+        }
+        refreshSettings();
+    }
+
+    public void resetSetting(Settings.Setting<?> setting, boolean global) {
+        Map<String, String> target = global ? this.globalOverrides : this.profileOverrides;
+        target.remove(setting.getName().toLowerCase(Locale.US));
+        refreshSettings();
+    }
+
+    public void setValue(Settings.Setting<?> setting, String rawValue, boolean global) {
+        SettingsUtil.parseAndApply(this.settings, setting.getName().toLowerCase(Locale.US), rawValue);
+        Map<String, String> target = global ? this.globalOverrides : this.profileOverrides;
+        target.put(setting.getName().toLowerCase(Locale.US), SettingsUtil.settingValueToString(setting));
+        refreshSettings();
+    }
+
+    public void saveScope(boolean global) {
+        if (global) {
+            saveGlobalOverrides();
+        } else {
+            saveActiveProfile();
+        }
+    }
+
+    public void saveGlobalOverrides() {
+        Map<String, String> relevant = filteredOverrides(this.globalOverrides, true);
+        SettingsUtil.writeRaw(SettingsUtil.SETTINGS_DEFAULT_NAME, relevant);
+    }
+
+    public void saveActiveProfile() {
+        if (SettingsUtil.SETTINGS_DEFAULT_NAME.equals(this.activeProfileFile)) {
+            saveGlobalOverrides();
+            return;
+        }
+        Map<String, String> relevant = filteredOverrides(this.profileOverrides, false);
+        SettingsUtil.writeRaw(this.activeProfileFile, relevant);
+    }
+
+    public String describeActiveProfile() {
+        return this.activeProfileDescription;
+    }
+
+    public String describeScope(boolean global) {
+        return global ? "the global profile" : describeActiveProfile();
+    }
+
+    public String getActiveProfileFile() {
+        return this.activeProfileFile;
+    }
+
+    private void refreshSettings() {
+        SettingsUtil.modifiedSettings(this.settings).forEach(Settings.Setting::reset);
+        applyOverrides(this.globalOverrides);
+        applyOverrides(this.profileOverrides);
+    }
+
+    private void applyOverrides(Map<String, String> overrides) {
+        overrides.forEach((settingName, value) -> {
+            try {
+                SettingsUtil.parseAndApply(this.settings, settingName, value);
+            } catch (Exception ex) {
+                Helper.HELPER.logDirect("Failed to apply setting " + settingName + " from profile");
+                ex.printStackTrace();
+            }
+        });
+    }
+
+    private Map<String, String> filteredOverrides(Map<String, String> overrides, boolean global) {
+        Map<String, String> filtered = new HashMap<>();
+        overrides.forEach((name, value) -> {
+            Settings.Setting<?> setting = this.settings.byLowerName.get(name);
+            if (setting == null) {
+                return;
+            }
+            String baseline = global
+                    ? SettingsUtil.settingDefaultToString(setting)
+                    : this.globalOverrides.getOrDefault(name, SettingsUtil.settingDefaultToString(setting));
+            if (!Objects.equals(value, baseline)) {
+                filtered.put(name, value);
+            }
+        });
+        return filtered;
+    }
+
+    private ProfileTarget computeProfileTarget() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft != null && minecraft.hasSingleplayerServer()) {
+            MinecraftServer server = minecraft.getSingleplayerServer();
+            if (server != null) {
+                Path worldPath = server.getWorldPath(LevelResource.ROOT).normalize();
+                String folderName = worldPath.getFileName() != null ? worldPath.getFileName().toString() : "singleplayer";
+                Path savesDir = minecraft.gameDirectory.toPath().resolve("saves");
+                if (worldPath.startsWith(savesDir) && savesDir.relativize(worldPath).getNameCount() > 0) {
+                    folderName = savesDir.relativize(worldPath).getName(0).toString();
+                }
+                String sanitized = sanitizeIdentifier(folderName);
+                if (sanitized.isEmpty()) {
+                    sanitized = "singleplayer";
+                }
+                String file = "settings/saves/" + sanitized + ".txt";
+                return new ProfileTarget(file, "world " + folderName);
+            }
+        }
+
+        if (minecraft != null) {
+            ServerData server = minecraft.getCurrentServer();
+            if (server != null) {
+                String identifier = server.ip == null || server.ip.isBlank() ? server.name : server.ip;
+                if (identifier == null || identifier.isBlank()) {
+                    identifier = "server";
+                }
+                if (server.isRealm()) {
+                    identifier = "realms_" + identifier;
+                }
+                String sanitized = sanitizeIdentifier(identifier);
+                if (sanitized.isEmpty()) {
+                    sanitized = "server";
+                }
+                String file = "settings/servers/" + sanitized + ".txt";
+                String description = server.name != null && !server.name.isBlank() ? server.name : identifier;
+                return new ProfileTarget(file, "server " + description);
+            }
+        }
+
+        return new ProfileTarget(SettingsUtil.SETTINGS_DEFAULT_NAME, "global profile");
+    }
+
+    private String sanitizeIdentifier(String raw) {
+        return INVALID_CHARACTERS.matcher(raw).replaceAll("_");
+    }
+
+    private static final class ProfileTarget {
+        final String file;
+        final String description;
+
+        private ProfileTarget(String file, String description) {
+            this.file = file;
+            this.description = description;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SettingsProfileManager that tracks the active server/world profile and layers it over global overrides
- extend SettingsUtil with reusable helpers so settings can be read from or written to arbitrary profile files
- update the set command to work with per-profile scopes, expose global overrides, and refresh tab completions/help text

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_b_68d9e24aaba8832fb0382901f1b3cf9e